### PR TITLE
fix(seedlings): add missing breakpoint in class names

### DIFF
--- a/packets/seedlings/src/_height.scss
+++ b/packets/seedlings/src/_height.scss
@@ -78,10 +78,10 @@ Breakpoints:
     @media #{$breakpoint} {
       @include height($breakpoint-name);
       @include percent-height($breakpoint-name);
-      .h-auto#{$breakpoint} {
+      .h-auto#{$breakpoint-name} {
         height: auto;
       }
-      .min-h-100#{$breakpoint} {
+      .min-h-100#{$breakpoint-name} {
         min-height: 100%;
       }
     }

--- a/packets/seedlings/src/_height.scss
+++ b/packets/seedlings/src/_height.scss
@@ -78,10 +78,10 @@ Breakpoints:
     @media #{$breakpoint} {
       @include height($breakpoint-name);
       @include percent-height($breakpoint-name);
-      .h-auto {
+      .h-auto#{$breakpoint} {
         height: auto;
       }
-      .min-h-100 {
+      .min-h-100#{$breakpoint} {
         min-height: 100%;
       }
     }


### PR DESCRIPTION
## Description:

The `h-auto` and `min-h-100` are missing the breakpoint variable so they are not working if you need to set those on a breakpoint. This just adds the breakpoint suffix to those 2 selectors.