### PR TITLE
[WEB-823] Allow for better documentation of utility classes

### DIFF
--- a/packets/seedlings/dist/seedlings-adapt.css
+++ b/packets/seedlings/dist/seedlings-adapt.css
@@ -65,6 +65,7 @@ Modifiers:
     separated: separated
     slash--up: slash up
     slash--down: slash down
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .appear {
@@ -316,6 +317,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .bg--twitter {
@@ -3454,6 +3456,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto b--neutral-300 w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .ba {
@@ -3553,6 +3556,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} ba bw600 mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .b--green-100 {
@@ -6500,6 +6504,8 @@ Modifiers:
     --bottom: bottom only
     --left: left only
     --x: rounded left & right
+
+Example: <div class="{{modifier}} mw900 mx-auto ba b--neutral-300 w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .br0 {
@@ -6539,6 +6545,7 @@ Modifiers:
     --dotted: dotted
     --dashed: dashed
     --solid: solid
+Example: <div class="{{modifier}} mw900 mx-auto ba b--neutral-300 w-100p pa350 mt400">{{label}}</div>
  */
 .b--dotted {
   border-style: dotted; }
@@ -6569,6 +6576,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto ba b--neutral-300 w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .bw500 {
@@ -6653,6 +6661,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .c--twitter {
@@ -11679,6 +11688,7 @@ Base:
 Modifiers:
     -proxima-nova: Proxima Nova
     -system: System Font Stack
+Example: <div class="mw900 mx-auto w-100p pa350 mt400">{{label}}<p class="{{modifier}}">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias, aliquid asperiores assumenda beatae doloremque ea eaque eum laudantium modi, molestiae odit repudiandae, totam ullam vel voluptate. Autem consequatur quam quidem?</p></div>
 ---
 */
 .ff-proxima-nova {
@@ -11701,6 +11711,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="mw900 mx-auto w-100p pa350 mt400">{{label}}<p class="{{modifier}}">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias, aliquid asperiores assumenda beatae doloremque ea eaque eum laudantium modi, molestiae odit repudiandae, totam ullam vel voluptate. Autem consequatur quam quidem?</p></div>
 ---
 */
 .fw-extrabold {
@@ -11782,6 +11793,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} bg--neutral-200 mw900 mx-auto w-100p px350 mt400 overflow-auto"><div>{{label}}</div></div>
 ---
 */
 .h0 {
@@ -12500,6 +12512,7 @@ Modifiers:
     lift: Hover Lift
     reveal: Hover Reveal
     pointer: Hover Pointer
+Example: <div class="mw900 mx-auto w-100p pa350 mt400"><a href="#" class="{{modifier}} db">{{label}}</a></div>
 ---
 */
 /*
@@ -13095,6 +13108,7 @@ Modifiers:
     o-20: Opacity .2
     o-10: Opacity .1
     o-0: Opacity 0
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
  */
 .o-100 {
@@ -13365,6 +13379,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .shadow100 {
@@ -13498,6 +13513,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} bg--neutral-200 mw900 mx-auto w-100p">{{label}}</div>
 ---
 */
 .ma-auto {
@@ -15781,6 +15797,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .strike {
@@ -16037,6 +16054,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .ttc {
@@ -16120,6 +16138,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .humongoose {
@@ -16550,6 +16569,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} db bg--neutral-200 py350 mt400 overflow-auto">{{label}}</div>
 ---
 */
 .w-auto {

--- a/packets/seedlings/dist/seedlings-bambu.css
+++ b/packets/seedlings/dist/seedlings-bambu.css
@@ -65,6 +65,7 @@ Modifiers:
     separated: separated
     slash--up: slash up
     slash--down: slash down
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .appear {
@@ -316,6 +317,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .bg--twitter {
@@ -3454,6 +3456,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto b--neutral-300 w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .ba {
@@ -3553,6 +3556,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} ba bw600 mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .b--green-100 {
@@ -6500,6 +6504,8 @@ Modifiers:
     --bottom: bottom only
     --left: left only
     --x: rounded left & right
+
+Example: <div class="{{modifier}} mw900 mx-auto ba b--neutral-300 w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .br0 {
@@ -6539,6 +6545,7 @@ Modifiers:
     --dotted: dotted
     --dashed: dashed
     --solid: solid
+Example: <div class="{{modifier}} mw900 mx-auto ba b--neutral-300 w-100p pa350 mt400">{{label}}</div>
  */
 .b--dotted {
   border-style: dotted; }
@@ -6569,6 +6576,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto ba b--neutral-300 w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .bw500 {
@@ -6653,6 +6661,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .c--twitter {
@@ -11679,6 +11688,7 @@ Base:
 Modifiers:
     -proxima-nova: Proxima Nova
     -system: System Font Stack
+Example: <div class="mw900 mx-auto w-100p pa350 mt400">{{label}}<p class="{{modifier}}">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias, aliquid asperiores assumenda beatae doloremque ea eaque eum laudantium modi, molestiae odit repudiandae, totam ullam vel voluptate. Autem consequatur quam quidem?</p></div>
 ---
 */
 .ff-proxima-nova {
@@ -11701,6 +11711,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="mw900 mx-auto w-100p pa350 mt400">{{label}}<p class="{{modifier}}">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias, aliquid asperiores assumenda beatae doloremque ea eaque eum laudantium modi, molestiae odit repudiandae, totam ullam vel voluptate. Autem consequatur quam quidem?</p></div>
 ---
 */
 .fw-extrabold {
@@ -11782,6 +11793,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} bg--neutral-200 mw900 mx-auto w-100p px350 mt400 overflow-auto"><div>{{label}}</div></div>
 ---
 */
 .h0 {
@@ -12500,6 +12512,7 @@ Modifiers:
     lift: Hover Lift
     reveal: Hover Reveal
     pointer: Hover Pointer
+Example: <div class="mw900 mx-auto w-100p pa350 mt400"><a href="#" class="{{modifier}} db">{{label}}</a></div>
 ---
 */
 /*
@@ -13095,6 +13108,7 @@ Modifiers:
     o-20: Opacity .2
     o-10: Opacity .1
     o-0: Opacity 0
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
  */
 .o-100 {
@@ -13365,6 +13379,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .shadow100 {
@@ -13498,6 +13513,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} bg--neutral-200 mw900 mx-auto w-100p">{{label}}</div>
 ---
 */
 .ma-auto {
@@ -15781,6 +15797,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .strike {
@@ -16037,6 +16054,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .ttc {
@@ -16120,6 +16138,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .humongoose {
@@ -16550,6 +16569,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} db bg--neutral-200 py350 mt400 overflow-auto">{{label}}</div>
 ---
 */
 .w-auto {

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -65,6 +65,7 @@ Modifiers:
     separated: separated
     slash--up: slash up
     slash--down: slash down
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .appear {
@@ -316,6 +317,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .bg--twitter {
@@ -3454,6 +3456,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto b--neutral-300 w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .ba {
@@ -3553,6 +3556,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} ba bw600 mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .b--green-100 {
@@ -6500,6 +6504,8 @@ Modifiers:
     --bottom: bottom only
     --left: left only
     --x: rounded left & right
+
+Example: <div class="{{modifier}} mw900 mx-auto ba b--neutral-300 w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .br0 {
@@ -6539,6 +6545,7 @@ Modifiers:
     --dotted: dotted
     --dashed: dashed
     --solid: solid
+Example: <div class="{{modifier}} mw900 mx-auto ba b--neutral-300 w-100p pa350 mt400">{{label}}</div>
  */
 .b--dotted {
   border-style: dotted; }
@@ -6569,6 +6576,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto ba b--neutral-300 w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .bw500 {
@@ -6653,6 +6661,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .c--twitter {
@@ -11679,6 +11688,7 @@ Base:
 Modifiers:
     -proxima-nova: Proxima Nova
     -system: System Font Stack
+Example: <div class="mw900 mx-auto w-100p pa350 mt400">{{label}}<p class="{{modifier}}">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias, aliquid asperiores assumenda beatae doloremque ea eaque eum laudantium modi, molestiae odit repudiandae, totam ullam vel voluptate. Autem consequatur quam quidem?</p></div>
 ---
 */
 .ff-proxima-nova {
@@ -11701,6 +11711,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="mw900 mx-auto w-100p pa350 mt400">{{label}}<p class="{{modifier}}">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias, aliquid asperiores assumenda beatae doloremque ea eaque eum laudantium modi, molestiae odit repudiandae, totam ullam vel voluptate. Autem consequatur quam quidem?</p></div>
 ---
 */
 .fw-extrabold {
@@ -11782,6 +11793,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} bg--neutral-200 mw900 mx-auto w-100p px350 mt400 overflow-auto"><div>{{label}}</div></div>
 ---
 */
 .h0 {
@@ -12500,6 +12512,7 @@ Modifiers:
     lift: Hover Lift
     reveal: Hover Reveal
     pointer: Hover Pointer
+Example: <div class="mw900 mx-auto w-100p pa350 mt400"><a href="#" class="{{modifier}} db">{{label}}</a></div>
 ---
 */
 /*
@@ -13095,6 +13108,7 @@ Modifiers:
     o-20: Opacity .2
     o-10: Opacity .1
     o-0: Opacity 0
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
  */
 .o-100 {
@@ -13365,6 +13379,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .shadow100 {
@@ -13498,6 +13513,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} bg--neutral-200 mw900 mx-auto w-100p">{{label}}</div>
 ---
 */
 .ma-auto {
@@ -15781,6 +15797,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .strike {
@@ -16037,6 +16054,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .ttc {
@@ -16120,6 +16138,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .humongoose {
@@ -16550,6 +16569,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} db bg--neutral-200 py350 mt400 overflow-auto">{{label}}</div>
 ---
 */
 .w-auto {

--- a/packets/seedlings/dist/seedlings-webapp.css
+++ b/packets/seedlings/dist/seedlings-webapp.css
@@ -132,6 +132,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .bg--twitter {
@@ -1188,6 +1189,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto b--neutral-300 w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .ba {
@@ -1227,6 +1229,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} ba bw600 mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .b--green-100 {
@@ -2218,6 +2221,8 @@ Modifiers:
     --bottom: bottom only
     --left: left only
     --x: rounded left & right
+
+Example: <div class="{{modifier}} mw900 mx-auto ba b--neutral-300 w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .br0 {
@@ -2257,6 +2262,7 @@ Modifiers:
     --dotted: dotted
     --dashed: dashed
     --solid: solid
+Example: <div class="{{modifier}} mw900 mx-auto ba b--neutral-300 w-100p pa350 mt400">{{label}}</div>
  */
 .b--dotted {
   border-style: dotted; }
@@ -2287,6 +2293,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto ba b--neutral-300 w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .bw500 {
@@ -2357,6 +2364,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .c--twitter {
@@ -4128,6 +4136,7 @@ Base:
 Modifiers:
     -proxima-nova: Proxima Nova
     -system: System Font Stack
+Example: <div class="mw900 mx-auto w-100p pa350 mt400">{{label}}<p class="{{modifier}}">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias, aliquid asperiores assumenda beatae doloremque ea eaque eum laudantium modi, molestiae odit repudiandae, totam ullam vel voluptate. Autem consequatur quam quidem?</p></div>
 ---
 */
 .ff-proxima-nova {
@@ -4150,6 +4159,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="mw900 mx-auto w-100p pa350 mt400">{{label}}<p class="{{modifier}}">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias, aliquid asperiores assumenda beatae doloremque ea eaque eum laudantium modi, molestiae odit repudiandae, totam ullam vel voluptate. Autem consequatur quam quidem?</p></div>
 ---
 */
 .fw-extrabold {
@@ -4201,6 +4211,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} bg--neutral-200 mw900 mx-auto w-100p px350 mt400 overflow-auto"><div>{{label}}</div></div>
 ---
 */
 .h0 {
@@ -4451,6 +4462,7 @@ Modifiers:
     lift: Hover Lift
     reveal: Hover Reveal
     pointer: Hover Pointer
+Example: <div class="mw900 mx-auto w-100p pa350 mt400"><a href="#" class="{{modifier}} db">{{label}}</a></div>
 ---
 */
 /*
@@ -4734,6 +4746,7 @@ Modifiers:
     o-20: Opacity .2
     o-10: Opacity .1
     o-0: Opacity 0
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
  */
 .o-100 {
@@ -4909,6 +4922,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} bg--neutral-200 mw900 mx-auto w-100p">{{label}}</div>
 ---
 */
 .ma-auto {
@@ -5668,6 +5682,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .strike {
@@ -5753,6 +5768,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .ttc {

--- a/packets/seedlings/src/_animation.scss
+++ b/packets/seedlings/src/_animation.scss
@@ -15,6 +15,7 @@ Modifiers:
     separated: separated
     slash--up: slash up
     slash--down: slash down
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 .appear {

--- a/packets/seedlings/src/_background.scss
+++ b/packets/seedlings/src/_background.scss
@@ -17,6 +17,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 

--- a/packets/seedlings/src/_border-color.scss
+++ b/packets/seedlings/src/_border-color.scss
@@ -14,6 +14,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} ba bw600 mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 @each $breakpoint-name, $breakpoint in $breakpoints {

--- a/packets/seedlings/src/_border-radius.scss
+++ b/packets/seedlings/src/_border-radius.scss
@@ -14,6 +14,8 @@ Modifiers:
     --bottom: bottom only
     --left: left only
     --x: rounded left & right
+
+Example: <div class="{{modifier}} mw900 mx-auto ba b--neutral-300 w-100p pa350 mt400">{{label}}</div>
 ---
 */
 @each $name, $size in $radiusSizes {

--- a/packets/seedlings/src/_border-style.scss
+++ b/packets/seedlings/src/_border-style.scss
@@ -7,6 +7,7 @@ Modifiers:
     --dotted: dotted
     --dashed: dashed
     --solid: solid
+Example: <div class="{{modifier}} mw900 mx-auto ba b--neutral-300 w-100p pa350 mt400">{{label}}</div>
  */
 
 .b--dotted  { border-style: dotted; }

--- a/packets/seedlings/src/_border-width.scss
+++ b/packets/seedlings/src/_border-width.scss
@@ -17,6 +17,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto ba b--neutral-300 w-100p pa350 mt400">{{label}}</div>
 ---
 */
 @mixin border-width($breakpoint-name: "") {

--- a/packets/seedlings/src/_border.scss
+++ b/packets/seedlings/src/_border.scss
@@ -16,6 +16,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto b--neutral-300 w-100p pa350 mt400">{{label}}</div>
 ---
 */
 

--- a/packets/seedlings/src/_color.scss
+++ b/packets/seedlings/src/_color.scss
@@ -13,6 +13,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 @each $breakpoint-name, $breakpoint in $breakpoints {

--- a/packets/seedlings/src/_font-family.scss
+++ b/packets/seedlings/src/_font-family.scss
@@ -7,6 +7,7 @@ Base:
 Modifiers:
     -proxima-nova: Proxima Nova
     -system: System Font Stack
+Example: <div class="mw900 mx-auto w-100p pa350 mt400">{{label}}<p class="{{modifier}}">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias, aliquid asperiores assumenda beatae doloremque ea eaque eum laudantium modi, molestiae odit repudiandae, totam ullam vel voluptate. Autem consequatur quam quidem?</p></div>
 ---
 */
 

--- a/packets/seedlings/src/_font-weight.scss
+++ b/packets/seedlings/src/_font-weight.scss
@@ -14,6 +14,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="mw900 mx-auto w-100p pa350 mt400">{{label}}<p class="{{modifier}}">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias, aliquid asperiores assumenda beatae doloremque ea eaque eum laudantium modi, molestiae odit repudiandae, totam ullam vel voluptate. Autem consequatur quam quidem?</p></div>
 ---
 */
 @mixin weight-scale($breakpoint-name: "") {

--- a/packets/seedlings/src/_height.scss
+++ b/packets/seedlings/src/_height.scss
@@ -37,6 +37,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} bg--neutral-200 mw900 mx-auto w-100p px350 mt400 overflow-auto"><div>{{label}}</div></div>
 ---
 */
 @mixin height($breakpoint-name: "") {

--- a/packets/seedlings/src/_hover.scss
+++ b/packets/seedlings/src/_hover.scss
@@ -9,6 +9,7 @@ Modifiers:
     lift: Hover Lift
     reveal: Hover Reveal
     pointer: Hover Pointer
+Example: <div class="mw900 mx-auto w-100p pa350 mt400"><a href="#" class="{{modifier}} db">{{label}}</a></div>
 ---
 */
 

--- a/packets/seedlings/src/_opacity.scss
+++ b/packets/seedlings/src/_opacity.scss
@@ -13,6 +13,7 @@ Modifiers:
     o-20: Opacity .2
     o-10: Opacity .1
     o-0: Opacity 0
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
  */
 

--- a/packets/seedlings/src/_shadow.scss
+++ b/packets/seedlings/src/_shadow.scss
@@ -16,6 +16,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 @mixin shadow($breakpoint-name: "") {

--- a/packets/seedlings/src/_spacing.scss
+++ b/packets/seedlings/src/_spacing.scss
@@ -37,6 +37,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} bg--neutral-200 mw900 mx-auto w-100p">{{label}}</div>
 ---
 */
 $space-map: (

--- a/packets/seedlings/src/_text-decoration.scss
+++ b/packets/seedlings/src/_text-decoration.scss
@@ -14,6 +14,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 @mixin overline($length: Space(700)) {

--- a/packets/seedlings/src/_text-transform.scss
+++ b/packets/seedlings/src/_text-transform.scss
@@ -15,6 +15,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 

--- a/packets/seedlings/src/_type-scale.scss
+++ b/packets/seedlings/src/_type-scale.scss
@@ -24,6 +24,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} mw900 mx-auto w-100p pa350 mt400">{{label}}</div>
 ---
 */
 

--- a/packets/seedlings/src/_width.scss
+++ b/packets/seedlings/src/_width.scss
@@ -68,6 +68,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="{{modifier}} db bg--neutral-200 py350 mt400 overflow-auto">{{label}}</div>
 ---
 */
 $grid-width: setUnits(1248px) !default;


### PR DESCRIPTION
## Description:

- At the moment its very hard to onboard new marketing developers because we have no place to display our utility classes and how to use them. This leverages our existing front matter set up and allows developers to pass an `Example` key and a string of HTML that will get manipulated

## Relevant Links

- [Test Site (Coming soon)](LINK TO TEST BOX)

### Related PRs

- https://github.com/sproutsocial/web-insights-application/pull/1688