### PR TITLE
[BCT-1179] Fix some nectar updates and add 8px border radius to seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,9 @@ Feel free to suggest additional scope options.
 
 ### Publishing Package Updates to npm
 
-- Put your PR changes in
+- Create a pull request against the `develop` branch
 - Get approval
-- Merge PR
-- Jenkins will take care of the rest!
+- Merge PR then create a new PR to the `master` branch and merge it. Jenkins will notify a successful build notifying that the seeds-packets were published to NPM, once that is complete create a final pull request from `master` to `develop`
 
 
 ### Testing packet changes locally

--- a/packets/seedlings/dist/seedlings-adapt.css
+++ b/packets/seedlings/dist/seedlings-adapt.css
@@ -6494,6 +6494,7 @@ Base:
 Modifiers:
     0: 0
     500: 500
+    800: 800
     --round: 50%
     --top: top only
     --right: right only
@@ -6507,6 +6508,9 @@ Modifiers:
 
 .br500 {
   border-radius: 6px; }
+
+.br800 {
+  border-radius: 8px; }
 
 .br--round {
   border-radius: 50%; }

--- a/packets/seedlings/dist/seedlings-adapt.css
+++ b/packets/seedlings/dist/seedlings-adapt.css
@@ -11696,7 +11696,7 @@ Modifiers:
 ---
 */
 .ff-proxima-nova {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif; }
+  font-family: "Proxima Nova", proxima-nova, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
 
 .ff-system {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif; }

--- a/packets/seedlings/dist/seedlings-adapt.css
+++ b/packets/seedlings/dist/seedlings-adapt.css
@@ -6507,7 +6507,7 @@ Modifiers:
   border-radius: 0; }
 
 .br500 {
-  border-radius: 6px; }
+  border-radius: 3px; }
 
 .br800 {
   border-radius: 8px; }

--- a/packets/seedlings/dist/seedlings-adapt.css
+++ b/packets/seedlings/dist/seedlings-adapt.css
@@ -6494,7 +6494,7 @@ Base:
 Modifiers:
     0: 0
     500: 500
-    800: 800
+    600: 600
     --round: 50%
     --top: top only
     --right: right only
@@ -6509,7 +6509,7 @@ Modifiers:
 .br500 {
   border-radius: 3px; }
 
-.br800 {
+.br600 {
   border-radius: 8px; }
 
 .br--round {

--- a/packets/seedlings/dist/seedlings-bambu.css
+++ b/packets/seedlings/dist/seedlings-bambu.css
@@ -6494,6 +6494,7 @@ Base:
 Modifiers:
     0: 0
     500: 500
+    800: 800
     --round: 50%
     --top: top only
     --right: right only
@@ -6507,6 +6508,9 @@ Modifiers:
 
 .br500 {
   border-radius: 6px; }
+
+.br800 {
+  border-radius: 8px; }
 
 .br--round {
   border-radius: 50%; }

--- a/packets/seedlings/dist/seedlings-bambu.css
+++ b/packets/seedlings/dist/seedlings-bambu.css
@@ -11696,7 +11696,7 @@ Modifiers:
 ---
 */
 .ff-proxima-nova {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif; }
+  font-family: "Proxima Nova", proxima-nova, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
 
 .ff-system {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif; }

--- a/packets/seedlings/dist/seedlings-bambu.css
+++ b/packets/seedlings/dist/seedlings-bambu.css
@@ -6507,7 +6507,7 @@ Modifiers:
   border-radius: 0; }
 
 .br500 {
-  border-radius: 6px; }
+  border-radius: 3px; }
 
 .br800 {
   border-radius: 8px; }

--- a/packets/seedlings/dist/seedlings-bambu.css
+++ b/packets/seedlings/dist/seedlings-bambu.css
@@ -6494,7 +6494,7 @@ Base:
 Modifiers:
     0: 0
     500: 500
-    800: 800
+    600: 600
     --round: 50%
     --top: top only
     --right: right only
@@ -6509,7 +6509,7 @@ Modifiers:
 .br500 {
   border-radius: 3px; }
 
-.br800 {
+.br600 {
   border-radius: 8px; }
 
 .br--round {

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -6494,6 +6494,7 @@ Base:
 Modifiers:
     0: 0
     500: 500
+    800: 800
     --round: 50%
     --top: top only
     --right: right only
@@ -6507,6 +6508,9 @@ Modifiers:
 
 .br500 {
   border-radius: 6px; }
+
+.br800 {
+  border-radius: 8px; }
 
 .br--round {
   border-radius: 50%; }

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -11696,7 +11696,7 @@ Modifiers:
 ---
 */
 .ff-proxima-nova {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif; }
+  font-family: "Proxima Nova", proxima-nova, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
 
 .ff-system {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif; }

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -6507,7 +6507,7 @@ Modifiers:
   border-radius: 0; }
 
 .br500 {
-  border-radius: 6px; }
+  border-radius: 3px; }
 
 .br800 {
   border-radius: 8px; }

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -6494,7 +6494,7 @@ Base:
 Modifiers:
     0: 0
     500: 500
-    800: 800
+    600: 600
     --round: 50%
     --top: top only
     --right: right only
@@ -6509,7 +6509,7 @@ Modifiers:
 .br500 {
   border-radius: 3px; }
 
-.br800 {
+.br600 {
   border-radius: 8px; }
 
 .br--round {

--- a/packets/seedlings/dist/seedlings-webapp.css
+++ b/packets/seedlings/dist/seedlings-webapp.css
@@ -2212,7 +2212,7 @@ Base:
 Modifiers:
     0: 0
     500: 500
-    800: 800
+    600: 600
     --round: 50%
     --top: top only
     --right: right only
@@ -2227,7 +2227,7 @@ Modifiers:
 .br500 {
   border-radius: 3px; }
 
-.br800 {
+.br600 {
   border-radius: 8px; }
 
 .br--round {

--- a/packets/seedlings/dist/seedlings-webapp.css
+++ b/packets/seedlings/dist/seedlings-webapp.css
@@ -2212,6 +2212,7 @@ Base:
 Modifiers:
     0: 0
     500: 500
+    800: 800
     --round: 50%
     --top: top only
     --right: right only
@@ -2225,6 +2226,9 @@ Modifiers:
 
 .br500 {
   border-radius: 6px; }
+
+.br800 {
+  border-radius: 8px; }
 
 .br--round {
   border-radius: 50%; }

--- a/packets/seedlings/dist/seedlings-webapp.css
+++ b/packets/seedlings/dist/seedlings-webapp.css
@@ -4139,7 +4139,7 @@ Modifiers:
 ---
 */
 .ff-proxima-nova {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif; }
+  font-family: "Proxima Nova", proxima-nova, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
 
 .ff-system {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif; }

--- a/packets/seedlings/dist/seedlings-webapp.css
+++ b/packets/seedlings/dist/seedlings-webapp.css
@@ -2225,7 +2225,7 @@ Modifiers:
   border-radius: 0; }
 
 .br500 {
-  border-radius: 6px; }
+  border-radius: 3px; }
 
 .br800 {
   border-radius: 8px; }

--- a/packets/seedlings/src/_border-radius.scss
+++ b/packets/seedlings/src/_border-radius.scss
@@ -8,7 +8,7 @@ Base:
 Modifiers:
     0: 0
     500: 500
-    800: 800
+    600: 600
     --round: 50%
     --top: top only
     --right: right only

--- a/packets/seedlings/src/_border-radius.scss
+++ b/packets/seedlings/src/_border-radius.scss
@@ -8,6 +8,7 @@ Base:
 Modifiers:
     0: 0
     500: 500
+    800: 800
     --round: 50%
     --top: top only
     --right: right only

--- a/packets/seedlings/src/_font-family.scss
+++ b/packets/seedlings/src/_font-family.scss
@@ -11,7 +11,7 @@ Modifiers:
 */
 
 .ff-proxima-nova {
-  font-family: $Typography-family;
+  font-family: $Typography-family--proxima;
 }
 
 .ff-system {

--- a/packets/seedlings/src/axioms/Border.scss
+++ b/packets/seedlings/src/axioms/Border.scss
@@ -2,14 +2,14 @@
 
 $borderSizes: (
         500: $Border-width--500,
-        600: 2px,
+        600: $Border-width--600,
         700: 5px,
         800: 8px
 );
 $radiusSizes: (
         0: 0,
-        500: $Border-radius--500,
-        800: 8px,
+        500: $Border-radius--400,
+        800: $Border-radius--600,
         --round: 50%
 );
 $sides: (

--- a/packets/seedlings/src/axioms/Border.scss
+++ b/packets/seedlings/src/axioms/Border.scss
@@ -9,7 +9,7 @@ $borderSizes: (
 $radiusSizes: (
         0: 0,
         500: $Border-radius--400,
-        800: $Border-radius--600,
+        600: $Border-radius--600,
         --round: 50%
 );
 $sides: (

--- a/packets/seedlings/src/axioms/Border.scss
+++ b/packets/seedlings/src/axioms/Border.scss
@@ -9,6 +9,7 @@ $borderSizes: (
 $radiusSizes: (
         0: 0,
         500: $Border-radius--500,
+        800: 8px,
         --round: 50%
 );
 $sides: (

--- a/packets/seeds-border/dist/seeds-border.css
+++ b/packets/seeds-border/dist/seeds-border.css
@@ -1,6 +1,8 @@
 :root {
+ --border-radius-400: 3px;
  --border-radius-500: 6px;
  --border-radius-600: 8px;
  --border-radius-1000: 999999px;
  --border-width-500: 1px;
+ --border-width-600: 2px;
 }

--- a/packets/seeds-border/dist/seeds-border.js
+++ b/packets/seeds-border/dist/seeds-border.js
@@ -1,8 +1,10 @@
 'use strict';
 
 module.exports = {
+	BORDER_RADIUS_400: '3px',
 	BORDER_RADIUS_500: '6px',
 	BORDER_RADIUS_600: '8px',
 	BORDER_RADIUS_1000: '999999px',
-	BORDER_WIDTH_500: '1px'
+	BORDER_WIDTH_500: '1px',
+	BORDER_WIDTH_600: '2px'
 };

--- a/packets/seeds-border/dist/seeds-border.scss
+++ b/packets/seeds-border/dist/seeds-border.scss
@@ -1,4 +1,6 @@
+$Border-radius--400: 3px;
 $Border-radius--500: 6px;
 $Border-radius--600: 8px;
 $Border-radius--1000: 999999px;
 $Border-width--500: 1px;
+$Border-width--600: 2px;

--- a/packets/seeds-border/dist/tokens.json
+++ b/packets/seeds-border/dist/tokens.json
@@ -1,6 +1,15 @@
 [
 	{
 		"category": "radius",
+		"sass": "$Border-radius--400",
+		"css": "--border-radius--400",
+		"javascript": "BORDER_RADIUS_400",
+		"app": "Radius 400",
+		"category": "radius",
+		"value": "3px"
+	},
+	{
+		"category": "radius",
 		"sass": "$Border-radius--500",
 		"css": "--border-radius--500",
 		"javascript": "BORDER_RADIUS_500",
@@ -34,5 +43,14 @@
 		"app": "Width 500",
 		"category": "width",
 		"value": "1px"
+	},
+	{
+		"category": "width",
+		"sass": "$Border-width--600",
+		"css": "--border-width--600",
+		"javascript": "BORDER_WIDTH_600",
+		"app": "Width 600",
+		"category": "width",
+		"value": "2px"
 	}
 ]

--- a/packets/seeds-border/tokens.json
+++ b/packets/seeds-border/tokens.json
@@ -1,12 +1,14 @@
 {
   "border": {
     "radius": {
+      "400": { "value": "3px" },
       "500": { "value": "6px" },
       "600": { "value": "8px" },
       "1000": { "value": "999999px" }
     },
     "width": {
-      "500": { "value": "1px" }
+      "500": { "value": "1px" },
+      "600": { "value": "2px" }
     }
   }
 }

--- a/packets/seeds-typography/dist/seeds-typography-unitless.js
+++ b/packets/seeds-typography/dist/seeds-typography-unitless.js
@@ -2,6 +2,7 @@
 
 module.exports = {
 	TYPOGRAPHY_FAMILY: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
+	TYPOGRAPHY_FAMILY_PROXIMA: '"Proxima Nova", proxima-nova, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
 	TYPOGRAPHY_SIZE_100: {
 		fontSize: 11,
     lineHeight: 18.666666666666668

--- a/packets/seeds-typography/dist/seeds-typography.css
+++ b/packets/seeds-typography/dist/seeds-typography.css
@@ -1,6 +1,7 @@
 :root {
 
   --typography-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  --typography-family--proxima: "Proxima Nova", proxima-nova, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 
   --typography-size--100: 11px;
   --typography-size--100-rem: 0.6111111111111112rem;

--- a/packets/seeds-typography/dist/seeds-typography.js
+++ b/packets/seeds-typography/dist/seeds-typography.js
@@ -2,6 +2,7 @@
 
 module.exports = {
 	TYPOGRAPHY_FAMILY: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
+	TYPOGRAPHY_FAMILY_PROXIMA: '"Proxima Nova", proxima-nova, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
 	TYPOGRAPHY_SIZE_100: {
 		fontSize: '11px',
     lineHeight: '18.666666666666668px'

--- a/packets/seeds-typography/dist/seeds-typography.scss
+++ b/packets/seeds-typography/dist/seeds-typography.scss
@@ -1,5 +1,6 @@
 
 $Typography-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+$Typography-family--proxima: "Proxima Nova", proxima-nova, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Helvetica, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 
 $Typography-size--100: 11px;
 @mixin Typography-size--100 {

--- a/packets/seeds-typography/dist/tokens.json
+++ b/packets/seeds-typography/dist/tokens.json
@@ -8,6 +8,14 @@
 	"value": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", \"Roboto\", \"Oxygen\", \"Ubuntu\", \"Cantarell\", \"Fira Sans\", \"Droid Sans\", \"Helvetica Neue\", sans-serif"
 },
 {
+	"category": "family",
+	"sass": "$Typography-family--proxima",
+	"css": "--typography-family--proxima",
+	"javascript": "TYPOGRAPHY_FAMILY_PROXIMA",
+	"app": "Family proxima",
+	"value": "\"Proxima Nova\", proxima-nova, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Helvetica, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\""
+},
+{
 	"category": "size",
 	"sass": "@include Typography-size--100;",
 	"css": "--typography-size--100",

--- a/packets/seeds-typography/tokens.json
+++ b/packets/seeds-typography/tokens.json
@@ -1,7 +1,8 @@
 {
   "typography": {
     "family": {
-      "family": { "value": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", \"Roboto\", \"Oxygen\", \"Ubuntu\", \"Cantarell\", \"Fira Sans\", \"Droid Sans\", \"Helvetica Neue\", sans-serif"}
+      "family": { "value": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", \"Roboto\", \"Oxygen\", \"Ubuntu\", \"Cantarell\", \"Fira Sans\", \"Droid Sans\", \"Helvetica Neue\", sans-serif"},
+      "proxima": { "value": "\"Proxima Nova\", proxima-nova, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Helvetica, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\"" }
     },
     "size": {
       "100": { "value": 11 },


### PR DESCRIPTION
## Description:

We're starting to make nectar updates to our marketing site, this PR is just adding the 8px border radius. Once those tokens are in seeds, we'll update this to use the new tokens. PR also addresses 2 regressions from https://github.com/sproutsocial/seeds-packets/commit/7f0971f3afea384dcf20a428a463438cee7b3deb#diff-96a3ec306c87a85de3d1f9abd813aaca

- [Test site](https://kevin-test.stagely.sproutsocial.com/border-radius-600/)

## Jira:

- [BCT-1179](https://sprout.atlassian.net/browse/BCT-1179)

## Screenshots:

<!--- Drag relevant screenshots into the GitHub edit window below -->
<img width="1254" alt="Screen Shot 2020-01-15 at 11 48 46 AM" src="https://user-images.githubusercontent.com/5562514/72457972-525d8b00-378d-11ea-9f3f-3ee674547c16.png">
