### PR TITLE
[BCT-3296] Add Scroll Snap utilities to seedlings

### DIFF
--- a/packets/seedlings/dist/seedlings-adapt.css
+++ b/packets/seedlings/dist/seedlings-adapt.css
@@ -13942,6 +13942,99 @@ Modifiers:
 
 /*
 ---
+Name: Scroll Snap
+Base:
+    scroll-snap: Scroll Snap
+Modifiers:
+    none: None
+    x: X-Axis
+    xmandatory: X-Axis (Mandatory)
+    y: Y-Axis
+    ymandatory: Y-Axis (Mandatory)
+Breakpoints:
+    -ns: not-small
+    -m: medium
+    -l: large
+---
+*/
+.scroll-snap-none {
+  scroll-snap-type: none; }
+
+.scroll-snap-x {
+  scroll-snap-type: x; }
+
+.scroll-snap-xmandatory {
+  scroll-snap-type: x mandatory; }
+
+.scroll-snap-y {
+  scroll-snap-type: y; }
+
+.scroll-snap-ymandatory {
+  scroll-snap-type: y mandatory; }
+
+.scroll-snap-none > *,
+.scroll-snap-x > *,
+.scroll-snap-xmandatory > *,
+.scroll-snap-y > *,
+.scroll-snap-ymandatory > * {
+  scroll-snap-align: center; }
+
+@media screen and (min-width: 30rem) {
+  .scroll-snap-none-ns {
+    scroll-snap-type: none; }
+  .scroll-snap-x-ns {
+    scroll-snap-type: x; }
+  .scroll-snap-xmandatory-ns {
+    scroll-snap-type: x mandatory; }
+  .scroll-snap-y-ns {
+    scroll-snap-type: y; }
+  .scroll-snap-ymandatory-ns {
+    scroll-snap-type: y mandatory; }
+  .scroll-snap-none-ns > *,
+  .scroll-snap-x-ns > *,
+  .scroll-snap-xmandatory-ns > *,
+  .scroll-snap-y-ns > *,
+  .scroll-snap-ymandatory-ns > * {
+    scroll-snap-align: center; } }
+
+@media screen and (min-width: 30rem) and (max-width: 60rem) {
+  .scroll-snap-none-m {
+    scroll-snap-type: none; }
+  .scroll-snap-x-m {
+    scroll-snap-type: x; }
+  .scroll-snap-xmandatory-m {
+    scroll-snap-type: x mandatory; }
+  .scroll-snap-y-m {
+    scroll-snap-type: y; }
+  .scroll-snap-ymandatory-m {
+    scroll-snap-type: y mandatory; }
+  .scroll-snap-none-m > *,
+  .scroll-snap-x-m > *,
+  .scroll-snap-xmandatory-m > *,
+  .scroll-snap-y-m > *,
+  .scroll-snap-ymandatory-m > * {
+    scroll-snap-align: center; } }
+
+@media screen and (min-width: 60rem) {
+  .scroll-snap-none-l {
+    scroll-snap-type: none; }
+  .scroll-snap-x-l {
+    scroll-snap-type: x; }
+  .scroll-snap-xmandatory-l {
+    scroll-snap-type: x mandatory; }
+  .scroll-snap-y-l {
+    scroll-snap-type: y; }
+  .scroll-snap-ymandatory-l {
+    scroll-snap-type: y mandatory; }
+  .scroll-snap-none-l > *,
+  .scroll-snap-x-l > *,
+  .scroll-snap-xmandatory-l > *,
+  .scroll-snap-y-l > *,
+  .scroll-snap-ymandatory-l > * {
+    scroll-snap-align: center; } }
+
+/*
+---
 Name: Shadow
 Base:
     shadow: shadow

--- a/packets/seedlings/dist/seedlings-adapt.css
+++ b/packets/seedlings/dist/seedlings-adapt.css
@@ -13946,7 +13946,7 @@ Name: Scroll Snap
 Base:
     scroll-snap: Scroll Snap
 Modifiers:
-    none: None
+    -none: None
     -x: X-Axis
     -xmandatory: X-Axis (Mandatory)
     -y: Y-Axis

--- a/packets/seedlings/dist/seedlings-adapt.css
+++ b/packets/seedlings/dist/seedlings-adapt.css
@@ -13947,10 +13947,10 @@ Base:
     scroll-snap: Scroll Snap
 Modifiers:
     none: None
-    x: X-Axis
-    xmandatory: X-Axis (Mandatory)
-    y: Y-Axis
-    ymandatory: Y-Axis (Mandatory)
+    -x: X-Axis
+    -xmandatory: X-Axis (Mandatory)
+    -y: Y-Axis
+    -ymandatory: Y-Axis (Mandatory)
 Breakpoints:
     -ns: not-small
     -m: medium

--- a/packets/seedlings/dist/seedlings-bambu.css
+++ b/packets/seedlings/dist/seedlings-bambu.css
@@ -13942,6 +13942,99 @@ Modifiers:
 
 /*
 ---
+Name: Scroll Snap
+Base:
+    scroll-snap: Scroll Snap
+Modifiers:
+    none: None
+    x: X-Axis
+    xmandatory: X-Axis (Mandatory)
+    y: Y-Axis
+    ymandatory: Y-Axis (Mandatory)
+Breakpoints:
+    -ns: not-small
+    -m: medium
+    -l: large
+---
+*/
+.scroll-snap-none {
+  scroll-snap-type: none; }
+
+.scroll-snap-x {
+  scroll-snap-type: x; }
+
+.scroll-snap-xmandatory {
+  scroll-snap-type: x mandatory; }
+
+.scroll-snap-y {
+  scroll-snap-type: y; }
+
+.scroll-snap-ymandatory {
+  scroll-snap-type: y mandatory; }
+
+.scroll-snap-none > *,
+.scroll-snap-x > *,
+.scroll-snap-xmandatory > *,
+.scroll-snap-y > *,
+.scroll-snap-ymandatory > * {
+  scroll-snap-align: center; }
+
+@media screen and (min-width: 30rem) {
+  .scroll-snap-none-ns {
+    scroll-snap-type: none; }
+  .scroll-snap-x-ns {
+    scroll-snap-type: x; }
+  .scroll-snap-xmandatory-ns {
+    scroll-snap-type: x mandatory; }
+  .scroll-snap-y-ns {
+    scroll-snap-type: y; }
+  .scroll-snap-ymandatory-ns {
+    scroll-snap-type: y mandatory; }
+  .scroll-snap-none-ns > *,
+  .scroll-snap-x-ns > *,
+  .scroll-snap-xmandatory-ns > *,
+  .scroll-snap-y-ns > *,
+  .scroll-snap-ymandatory-ns > * {
+    scroll-snap-align: center; } }
+
+@media screen and (min-width: 30rem) and (max-width: 60rem) {
+  .scroll-snap-none-m {
+    scroll-snap-type: none; }
+  .scroll-snap-x-m {
+    scroll-snap-type: x; }
+  .scroll-snap-xmandatory-m {
+    scroll-snap-type: x mandatory; }
+  .scroll-snap-y-m {
+    scroll-snap-type: y; }
+  .scroll-snap-ymandatory-m {
+    scroll-snap-type: y mandatory; }
+  .scroll-snap-none-m > *,
+  .scroll-snap-x-m > *,
+  .scroll-snap-xmandatory-m > *,
+  .scroll-snap-y-m > *,
+  .scroll-snap-ymandatory-m > * {
+    scroll-snap-align: center; } }
+
+@media screen and (min-width: 60rem) {
+  .scroll-snap-none-l {
+    scroll-snap-type: none; }
+  .scroll-snap-x-l {
+    scroll-snap-type: x; }
+  .scroll-snap-xmandatory-l {
+    scroll-snap-type: x mandatory; }
+  .scroll-snap-y-l {
+    scroll-snap-type: y; }
+  .scroll-snap-ymandatory-l {
+    scroll-snap-type: y mandatory; }
+  .scroll-snap-none-l > *,
+  .scroll-snap-x-l > *,
+  .scroll-snap-xmandatory-l > *,
+  .scroll-snap-y-l > *,
+  .scroll-snap-ymandatory-l > * {
+    scroll-snap-align: center; } }
+
+/*
+---
 Name: Shadow
 Base:
     shadow: shadow

--- a/packets/seedlings/dist/seedlings-bambu.css
+++ b/packets/seedlings/dist/seedlings-bambu.css
@@ -13946,7 +13946,7 @@ Name: Scroll Snap
 Base:
     scroll-snap: Scroll Snap
 Modifiers:
-    none: None
+    -none: None
     -x: X-Axis
     -xmandatory: X-Axis (Mandatory)
     -y: Y-Axis

--- a/packets/seedlings/dist/seedlings-bambu.css
+++ b/packets/seedlings/dist/seedlings-bambu.css
@@ -13947,10 +13947,10 @@ Base:
     scroll-snap: Scroll Snap
 Modifiers:
     none: None
-    x: X-Axis
-    xmandatory: X-Axis (Mandatory)
-    y: Y-Axis
-    ymandatory: Y-Axis (Mandatory)
+    -x: X-Axis
+    -xmandatory: X-Axis (Mandatory)
+    -y: Y-Axis
+    -ymandatory: Y-Axis (Mandatory)
 Breakpoints:
     -ns: not-small
     -m: medium

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -13942,6 +13942,99 @@ Modifiers:
 
 /*
 ---
+Name: Scroll Snap
+Base:
+    scroll-snap: Scroll Snap
+Modifiers:
+    none: None
+    x: X-Axis
+    xmandatory: X-Axis (Mandatory)
+    y: Y-Axis
+    ymandatory: Y-Axis (Mandatory)
+Breakpoints:
+    -ns: not-small
+    -m: medium
+    -l: large
+---
+*/
+.scroll-snap-none {
+  scroll-snap-type: none; }
+
+.scroll-snap-x {
+  scroll-snap-type: x; }
+
+.scroll-snap-xmandatory {
+  scroll-snap-type: x mandatory; }
+
+.scroll-snap-y {
+  scroll-snap-type: y; }
+
+.scroll-snap-ymandatory {
+  scroll-snap-type: y mandatory; }
+
+.scroll-snap-none > *,
+.scroll-snap-x > *,
+.scroll-snap-xmandatory > *,
+.scroll-snap-y > *,
+.scroll-snap-ymandatory > * {
+  scroll-snap-align: center; }
+
+@media screen and (min-width: 30rem) {
+  .scroll-snap-none-ns {
+    scroll-snap-type: none; }
+  .scroll-snap-x-ns {
+    scroll-snap-type: x; }
+  .scroll-snap-xmandatory-ns {
+    scroll-snap-type: x mandatory; }
+  .scroll-snap-y-ns {
+    scroll-snap-type: y; }
+  .scroll-snap-ymandatory-ns {
+    scroll-snap-type: y mandatory; }
+  .scroll-snap-none-ns > *,
+  .scroll-snap-x-ns > *,
+  .scroll-snap-xmandatory-ns > *,
+  .scroll-snap-y-ns > *,
+  .scroll-snap-ymandatory-ns > * {
+    scroll-snap-align: center; } }
+
+@media screen and (min-width: 30rem) and (max-width: 60rem) {
+  .scroll-snap-none-m {
+    scroll-snap-type: none; }
+  .scroll-snap-x-m {
+    scroll-snap-type: x; }
+  .scroll-snap-xmandatory-m {
+    scroll-snap-type: x mandatory; }
+  .scroll-snap-y-m {
+    scroll-snap-type: y; }
+  .scroll-snap-ymandatory-m {
+    scroll-snap-type: y mandatory; }
+  .scroll-snap-none-m > *,
+  .scroll-snap-x-m > *,
+  .scroll-snap-xmandatory-m > *,
+  .scroll-snap-y-m > *,
+  .scroll-snap-ymandatory-m > * {
+    scroll-snap-align: center; } }
+
+@media screen and (min-width: 60rem) {
+  .scroll-snap-none-l {
+    scroll-snap-type: none; }
+  .scroll-snap-x-l {
+    scroll-snap-type: x; }
+  .scroll-snap-xmandatory-l {
+    scroll-snap-type: x mandatory; }
+  .scroll-snap-y-l {
+    scroll-snap-type: y; }
+  .scroll-snap-ymandatory-l {
+    scroll-snap-type: y mandatory; }
+  .scroll-snap-none-l > *,
+  .scroll-snap-x-l > *,
+  .scroll-snap-xmandatory-l > *,
+  .scroll-snap-y-l > *,
+  .scroll-snap-ymandatory-l > * {
+    scroll-snap-align: center; } }
+
+/*
+---
 Name: Shadow
 Base:
     shadow: shadow

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -13946,7 +13946,7 @@ Name: Scroll Snap
 Base:
     scroll-snap: Scroll Snap
 Modifiers:
-    none: None
+    -none: None
     -x: X-Axis
     -xmandatory: X-Axis (Mandatory)
     -y: Y-Axis

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -13947,10 +13947,10 @@ Base:
     scroll-snap: Scroll Snap
 Modifiers:
     none: None
-    x: X-Axis
-    xmandatory: X-Axis (Mandatory)
-    y: Y-Axis
-    ymandatory: Y-Axis (Mandatory)
+    -x: X-Axis
+    -xmandatory: X-Axis (Mandatory)
+    -y: Y-Axis
+    -ymandatory: Y-Axis (Mandatory)
 Breakpoints:
     -ns: not-small
     -m: medium

--- a/packets/seedlings/seedlings-marketing.scss
+++ b/packets/seedlings/seedlings-marketing.scss
@@ -56,6 +56,7 @@ $grid-width: setUnits(1248px) !default;
 @import 'src/overflow';
 @import 'src/position';
 @import 'src/print';
+@import 'src/scroll-snap';
 @import 'src/shadow';
 @import 'src/spacing';
 @import 'src/square';

--- a/packets/seedlings/src/_scroll-snap.scss
+++ b/packets/seedlings/src/_scroll-snap.scss
@@ -5,10 +5,10 @@ Base:
     scroll-snap: Scroll Snap
 Modifiers:
     none: None
-    x: X-Axis
-    xmandatory: X-Axis (Mandatory)
-    y: Y-Axis
-    ymandatory: Y-Axis (Mandatory)
+    -x: X-Axis
+    -xmandatory: X-Axis (Mandatory)
+    -y: Y-Axis
+    -ymandatory: Y-Axis (Mandatory)
 Breakpoints:
     -ns: not-small
     -m: medium

--- a/packets/seedlings/src/_scroll-snap.scss
+++ b/packets/seedlings/src/_scroll-snap.scss
@@ -1,0 +1,52 @@
+/*
+---
+Name: Scroll Snap
+Base:
+    scroll-snap: Scroll Snap
+Modifiers:
+    none: None
+    x: X-Axis
+    xmandatory: X-Axis (Mandatory)
+    y: Y-Axis
+    ymandatory: Y-Axis (Mandatory)
+Breakpoints:
+    -ns: not-small
+    -m: medium
+    -l: large
+---
+*/
+
+@mixin snap($breakpoint-name: "") {
+  .scroll-snap-none#{$breakpoint-name} {
+    scroll-snap-type: none;
+  }
+  .scroll-snap-x#{$breakpoint-name} {
+    scroll-snap-type: x;
+  }
+  .scroll-snap-xmandatory#{$breakpoint-name} {
+    scroll-snap-type: x mandatory;
+  }
+  .scroll-snap-y#{$breakpoint-name} {
+    scroll-snap-type: y;
+  }
+  .scroll-snap-ymandatory#{$breakpoint-name} {
+    scroll-snap-type: y mandatory;
+  }
+  .scroll-snap-none#{$breakpoint-name} > *,
+  .scroll-snap-x#{$breakpoint-name} > *,
+  .scroll-snap-xmandatory#{$breakpoint-name} > *,
+  .scroll-snap-y#{$breakpoint-name} > *,
+  .scroll-snap-ymandatory#{$breakpoint-name} > * {
+    scroll-snap-align: center;
+  }
+}
+
+@each $breakpoint-name, $breakpoint in $breakpoints {
+  @if ($breakpoint != "") {
+    @media #{$breakpoint} {
+      @include snap($breakpoint-name);
+    }
+  } @else {
+    @include snap;
+  }
+}

--- a/packets/seedlings/src/_scroll-snap.scss
+++ b/packets/seedlings/src/_scroll-snap.scss
@@ -4,7 +4,7 @@ Name: Scroll Snap
 Base:
     scroll-snap: Scroll Snap
 Modifiers:
-    none: None
+    -none: None
     -x: X-Axis
     -xmandatory: X-Axis (Mandatory)
     -y: Y-Axis


### PR DESCRIPTION
## Description:

* Adds utilities for the CSS Scroll Snap module (https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Scroll_Snap)

## Relevant Links

- [BCT-3296](https://sprout.atlassian.net/browse/BCT-3296)
- [Test Site](https://stanton-test.stagely.sproutsocial.com/scroll-snap-example/)
