### PR TITLE
[BCT-1130] Update separate shadow pattern for new stake layout

### DIFF
--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -153,7 +153,10 @@ Modifiers:
   transform: translate(0.44444rem, 0.44444rem); }
 
 .separate--shadow {
-  box-shadow: 0.88889rem 0.88889rem 0 #002838; }
+  box-shadow: -0.88889rem -0.88889rem 0 #002138; }
+  @media screen and (min-width: 960px) {
+    .separate--shadow {
+      box-shadow: -2.22222rem -2.22222rem 0 #002138; } }
 
 @keyframes separateUp {
   from {

--- a/packets/seedlings/src/_animation.scss
+++ b/packets/seedlings/src/_animation.scss
@@ -96,7 +96,10 @@ Modifiers:
   transform: translate(Space(300), Space(300));
 }
 .separate--shadow {
-  box-shadow: Space(400) Space(400) 0 get-color(aqua, 1100);
+  box-shadow: -#{Space(400)} -#{Space(400)} 0 get-color(blue, 1100);
+  @media #{$breakpoint-large} {
+    box-shadow: -#{Space(600)} -#{Space(600)} 0 get-color(blue, 1100);
+  }
 }
 @keyframes separateUp {
   from {


### PR DESCRIPTION
## Description:

- We use our `separate--shadow` pattern to have that offset pattern, but now its top and left apposed to bottom right, also on desktop it has a larger offset.

## Relevant Links

- [Test site](https://justin-test.stagely.sproutsocial.com/travel-industry/?amp)

### Related PRs

- https://github.com/sproutsocial/web-insights-application/pull/2424
