### PR TITLE
[BCT-265] Add examples of utilities

### DIFF
--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -40,6 +40,7 @@ Modifiers:
 Name: Accessibility
 Modifiers:
     screenreader: screenreader
+Example: <span class="{{modifier}}">I am secret text only readable by AT</span><p>{{label}}</p>
 ---
 */
 .screenreader {
@@ -313,16 +314,18 @@ Modifiers:
     -transparent: transparent
     --dark-translucent: dark transparent
     --light-translucent: light transparent
-    --bg--teal-700-o-30p: teal 700 (30% opacity)
-    --bg--neutral-0-o-10p: neutral 0 (10% opacity)
-    --bg--neutral-0-o-30p: neutral 0 (30% opacity)
-    --bg--neutral-0-o-80p: neutral 0 (80% opacity)
+    --teal-700-o-30p: Teal 700 (30% opacity)
+    --neutral-0-o-10p: Neutral 0 (10% opacity)
+    --neutral-0-o-30p: Neutral 0 (30% opacity)
+    --neutral-0-o-80p: Neutral 0 (80% opacity)
     --color-name: name of a color variable
 Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
 HoverClasses: true
+Description: Background is our utilities to allow for setting background colors with both breakpoints and hover states
+Example: <div class="db pa300 {{modifier}}">{{label}}</div>
 ---
 */
 .bg--twitter {
@@ -3839,6 +3842,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db square700 bw600 b--neutral-200 {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 .ba {
@@ -3938,6 +3942,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 .b--green-0 {
@@ -7068,6 +7073,7 @@ Modifiers:
     --left: left only
     --leaf: leaf frame
     --x: rounded left & right
+Example: <div class="db square750 bg--neutral-200 overflow-hidden {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 .br0 {
@@ -7120,6 +7126,7 @@ Modifiers:
     --dotted: dotted
     --dashed: dashed
     --solid: solid
+Example: <div class="ba bw600 b--neutral-200 square750 {{modifier}}"></div><p>{{label}}</p>
  */
 .b--dotted {
   border-style: dotted; }
@@ -7151,6 +7158,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="ba b--neutral-200 db square750 {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 .bw500 {
@@ -7244,6 +7252,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the lazy dog</p></div><p>{{label}}</p>
 ---
 */
 .c--twitter {
@@ -13564,6 +13573,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db bg--blue-700 py200 {{modifier}}"><img src="https://media.sproutsocial.com/uploads/LGO_Shopify-2.svg" loading="lazy" /></div><p>{{label}}</p>
 ---
 */
 @supports (filter: none) {
@@ -14152,6 +14162,7 @@ Modifiers:
     -proxima-nova: Proxima Nova
     -system: System Font Stack
     -recoleta: Recoleta semi-bold
+Example: <div class="f500 {{modifier}}">The quick brown fox jumps over the lazy dog</div><p>{{label}}</p>
 ---
 */
 .ff-proxima-nova {
@@ -14177,6 +14188,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db f500 {{modifier}}">The quick brown fox..</div><p>{{label}}</p>
 ---
 */
 .fw-extrabold {
@@ -14258,6 +14270,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db bg--neutral-200 {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 .h0 {
@@ -15618,6 +15631,7 @@ Modifiers:
     o-20: Opacity .2
     o-10: Opacity .1
     o-0: Opacity 0
+Example: <div class="db bg--neutral-900 square750 {{modifier}}"></div><p>{{label}}</p>
 ---
  */
 .o-100 {
@@ -16207,6 +16221,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="db square750 bg--neutral-200 {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 .shadow100 {
@@ -16355,6 +16370,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db square750 bg--neutral-200 {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 /*
@@ -16374,6 +16390,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db bg--neutral-200 {{modifier}}">The quick brown fox...</div><p>{{label}}</p>
 ---
 */
 .ma-auto {
@@ -18988,6 +19005,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db bg--neutral-200 {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 .square-auto {
@@ -19244,6 +19262,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="f500 {{modifier}}">The quick brown fox jumps over the lazy dog</div><p>{{label}}</p>
 ---
 */
 .tl {
@@ -19304,6 +19323,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="db f500 {{modifier}}">The quick brown fox...</div><p>{{label}}</p>
 ---
 */
 .strike {
@@ -19560,6 +19580,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db f500 {{modifier}}">The quick brown fox...</div><p>{{label}}</p>
 ---
 */
 .ttc {
@@ -19643,6 +19664,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy dog</div><p>{{label}}</p>
 ---
 */
 .humongoose {
@@ -20221,6 +20243,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="dib bg--neutral-200 py300 {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 .w-auto {

--- a/packets/seedlings/src/_accessibility.scss
+++ b/packets/seedlings/src/_accessibility.scss
@@ -3,6 +3,7 @@
 Name: Accessibility
 Modifiers:
     screenreader: screenreader
+Example: <span class="{{modifier}}">I am secret text only readable by AT</span><p>{{label}}</p>
 ---
 */
 

--- a/packets/seedlings/src/_background.scss
+++ b/packets/seedlings/src/_background.scss
@@ -1,4 +1,3 @@
-
 @import "./axioms/Colors";
 
 /*
@@ -21,6 +20,8 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Description: Background is our utilities to allow for setting background colors with both breakpoints and hover states
+Example: <div class="db pa300 {{modifier}}">{{label}}</div>
 ---
 */
 

--- a/packets/seedlings/src/_border-color.scss
+++ b/packets/seedlings/src/_border-color.scss
@@ -14,6 +14,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 @each $breakpoint-name, $breakpoint in $breakpoints {

--- a/packets/seedlings/src/_border-radius.scss
+++ b/packets/seedlings/src/_border-radius.scss
@@ -17,6 +17,7 @@ Modifiers:
     --left: left only
     --leaf: leaf frame
     --x: rounded left & right
+Example: <div class="db square750 bg--neutral-200 overflow-hidden {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 @each $name, $size in $radiusSizes {

--- a/packets/seedlings/src/_border-style.scss
+++ b/packets/seedlings/src/_border-style.scss
@@ -7,6 +7,7 @@ Modifiers:
     --dotted: dotted
     --dashed: dashed
     --solid: solid
+Example: <div class="ba bw600 b--neutral-200 square750 {{modifier}}"></div><p>{{label}}</p>
  */
 
 .b--dotted  { border-style: dotted; }

--- a/packets/seedlings/src/_border-width.scss
+++ b/packets/seedlings/src/_border-width.scss
@@ -18,6 +18,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="ba b--neutral-200 db square750 {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 @mixin border-width($breakpoint-name: "") {

--- a/packets/seedlings/src/_border.scss
+++ b/packets/seedlings/src/_border.scss
@@ -16,6 +16,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db square700 bw600 b--neutral-200 {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 

--- a/packets/seedlings/src/_color.scss
+++ b/packets/seedlings/src/_color.scss
@@ -13,6 +13,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the lazy dog</p></div><p>{{label}}</p>
 ---
 */
 @each $breakpoint-name, $breakpoint in $breakpoints {

--- a/packets/seedlings/src/_filter.scss
+++ b/packets/seedlings/src/_filter.scss
@@ -11,6 +11,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db bg--blue-700 py200 {{modifier}}"><img src="https://media.sproutsocial.com/uploads/LGO_Shopify-2.svg" loading="lazy" /></div><p>{{label}}</p>
 ---
 */
 

--- a/packets/seedlings/src/_font-family.scss
+++ b/packets/seedlings/src/_font-family.scss
@@ -8,6 +8,7 @@ Modifiers:
     -proxima-nova: Proxima Nova
     -system: System Font Stack
     -recoleta: Recoleta semi-bold
+Example: <div class="f500 {{modifier}}">The quick brown fox jumps over the lazy dog</div><p>{{label}}</p>
 ---
 */
 

--- a/packets/seedlings/src/_font-weight.scss
+++ b/packets/seedlings/src/_font-weight.scss
@@ -14,6 +14,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db f500 {{modifier}}">The quick brown fox..</div><p>{{label}}</p>
 ---
 */
 @mixin weight-scale($breakpoint-name: "") {

--- a/packets/seedlings/src/_height.scss
+++ b/packets/seedlings/src/_height.scss
@@ -37,6 +37,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db bg--neutral-200 {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 @mixin height($breakpoint-name: "") {

--- a/packets/seedlings/src/_opacity.scss
+++ b/packets/seedlings/src/_opacity.scss
@@ -13,6 +13,7 @@ Modifiers:
     o-20: Opacity .2
     o-10: Opacity .1
     o-0: Opacity 0
+Example: <div class="db bg--neutral-900 square750 {{modifier}}"></div><p>{{label}}</p>
 ---
  */
 

--- a/packets/seedlings/src/_shadow.scss
+++ b/packets/seedlings/src/_shadow.scss
@@ -17,6 +17,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="db square750 bg--neutral-200 {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 @mixin shadow($breakpoint-name: "") {

--- a/packets/seedlings/src/_spacing.scss
+++ b/packets/seedlings/src/_spacing.scss
@@ -38,6 +38,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db square750 bg--neutral-200 {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 
@@ -58,6 +59,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db bg--neutral-200 {{modifier}}">The quick brown fox...</div><p>{{label}}</p>
 ---
 */
 

--- a/packets/seedlings/src/_square.scss
+++ b/packets/seedlings/src/_square.scss
@@ -29,6 +29,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db bg--neutral-200 {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 

--- a/packets/seedlings/src/_text-align.scss
+++ b/packets/seedlings/src/_text-align.scss
@@ -12,6 +12,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="f500 {{modifier}}">The quick brown fox jumps over the lazy dog</div><p>{{label}}</p>
 ---
 */
 

--- a/packets/seedlings/src/_text-decoration.scss
+++ b/packets/seedlings/src/_text-decoration.scss
@@ -14,6 +14,7 @@ Breakpoints:
     -m: medium
     -l: large
 HoverClasses: true
+Example: <div class="db f500 {{modifier}}">The quick brown fox...</div><p>{{label}}</p>
 ---
 */
 @mixin overline($length: Space(700)) {

--- a/packets/seedlings/src/_text-transform.scss
+++ b/packets/seedlings/src/_text-transform.scss
@@ -15,6 +15,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db f500 {{modifier}}">The quick brown fox...</div><p>{{label}}</p>
 ---
 */
 

--- a/packets/seedlings/src/_type-scale.scss
+++ b/packets/seedlings/src/_type-scale.scss
@@ -24,6 +24,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy dog</div><p>{{label}}</p>
 ---
 */
 

--- a/packets/seedlings/src/_width.scss
+++ b/packets/seedlings/src/_width.scss
@@ -68,6 +68,7 @@ Breakpoints:
     -ns: not-small
     -m: medium
     -l: large
+Example: <div class="dib bg--neutral-200 py300 {{modifier}}"></div><p>{{label}}</p>
 ---
 */
 @mixin width($breakpoint-name: "") {


### PR DESCRIPTION
## Description:

* Adds an example field to our utility front matter to be used to display them visually

## Relevant Links

- [BCT-265](https://sprout.atlassian.net/browse/BCT-265)
- [Test site](https://marketing-test.stagely.sproutsocial.com/utilities/)

## Screenshots:

<img width="1904" alt="Screen Shot 2021-12-08 at 5 42 53 PM" src="https://user-images.githubusercontent.com/1868805/145308725-394b0777-a1b6-4cda-aa1c-ae25b1fffabb.png">
