### PR TITLE
[DAR-34] feat(seeds-depth)!: remove color from depth values

### DIFF
--- a/packets/seeds-depth/tokens.json
+++ b/packets/seeds-depth/tokens.json
@@ -1,10 +1,10 @@
 {
   "elevation": {
     "level": {
-      "100": { "value": "0px 2px 4px rgba(39,51,51,.24)" },
-      "200": { "value": "0px 4px 8px rgba(39,51,51,.24)" },
-      "300": { "value": "0px 8px 16px rgba(39,51,51,.24)" },
-      "400": { "value": "0px 16px 32px rgba(39,51,51,.24)" }
+      "100": { "value": "0px 2px 4px" },
+      "200": { "value": "0px 4px 8px" },
+      "300": { "value": "0px 8px 16px" },
+      "400": { "value": "0px 16px 32px" }
     }
   }
 }


### PR DESCRIPTION
Decoupling color from depth will allow for future dark mode possibilities

BREAKING CHANGE: color will no longer be available as a part of depth. Any instance of depth will have to be fixed to include the correct rgba value


## Description:

- Removed hardcoded color from depth package

## Jira:
https://sprout.atlassian.net/jira/software/c/projects/DS/boards/601?modal=detail&selectedIssue=DAR-34&assignee=61683a6b07ac3c0068a2771a

## Screenshots:

<!--- Drag relevant screenshots into the GitHub edit window below -->

closes DAR-34