### PR TITLE
MBC-7555 - Update type scale utilities to be consistent

### DIFF
--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -19887,7 +19887,6 @@ Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy do
   line-height: 1.3333333333333333; }
 
 .f700 {
-  color: red;
   font-size: 1.77778rem;
   line-height: 1.25; }
 
@@ -19900,8 +19899,8 @@ Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy do
   line-height: 1.1228070175438596; }
 
 .f1000 {
-  font-size: 3.16667rem;
-  line-height: 1.1228070175438596; }
+  font-size: 4.22222rem;
+  line-height: 1.0526315789473684; }
 
 .f1100 {
   font-size: 5.61111rem;
@@ -19910,6 +19909,79 @@ Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy do
 .f1200 {
   font-size: 7.5rem;
   line-height: 0.928395061728395; }
+
+html.legacy-type-scale .f600 {
+  font-size: 1.16667rem;
+  line-height: 1.3968253968253967; }
+  @media screen and (min-width: 480px) {
+    html.legacy-type-scale .f600 {
+      font-size: 1.33333rem;
+      line-height: 1.3333333333333333; } }
+
+html.legacy-type-scale .f700 {
+  font-size: 1.33333rem;
+  line-height: 1.3333333333333333; }
+  @media screen and (min-width: 480px) {
+    html.legacy-type-scale .f700 {
+      font-size: 1.77778rem;
+      line-height: 1.25; } }
+
+html.legacy-type-scale .f800 {
+  font-size: 1.77778rem;
+  line-height: 1.25; }
+  @media screen and (min-width: 480px) {
+    html.legacy-type-scale .f800 {
+      font-size: 2.38889rem;
+      line-height: 1.1782945736434107; } }
+
+html.legacy-type-scale .f900 {
+  font-size: 2.38889rem;
+  line-height: 1.1782945736434107; }
+  @media screen and (min-width: 480px) {
+    html.legacy-type-scale .f900 {
+      font-size: 3.16667rem;
+      line-height: 1.1228070175438596; } }
+
+html.legacy-type-scale .f1000 {
+  font-size: 2.38889rem;
+  line-height: 1.1782945736434107; }
+  @media screen and (min-width: 480px) {
+    html.legacy-type-scale .f1000 {
+      font-size: 3.16667rem;
+      line-height: 1.1228070175438596; } }
+  @media screen and (min-width: 480px) {
+    html.legacy-type-scale .f1000 {
+      font-size: 4.22222rem;
+      line-height: 1.0526315789473684; } }
+
+html.legacy-type-scale .f1100 {
+  font-size: 3.16667rem;
+  line-height: 1.1228070175438596; }
+  @media screen and (min-width: 480px) and (max-width: 959px) {
+    html.legacy-type-scale .f1100 {
+      font-size: 4.22222rem;
+      line-height: 1.0526315789473684; } }
+  @media screen and (min-width: 960px) {
+    html.legacy-type-scale .f1100 {
+      font-size: 5.61111rem;
+      line-height: 1.0033003300330032; } }
+
+html.legacy-type-scale .f1200 {
+  font-size: 3.16667rem;
+  line-height: 1.1228070175438596; }
+  @media screen and (min-width: 480px) and (max-width: 959px) {
+    html.legacy-type-scale .f1200 {
+      font-size: 4.22222rem;
+      line-height: 1.0526315789473684; } }
+  @media screen and (min-width: 960px) {
+    html.legacy-type-scale .f1200 {
+      font-size: 7.5rem;
+      line-height: 0.928395061728395; } }
+
+section#type-scale div.db {
+  margin-top: 3.0rem; }
+  section#type-scale div.db:first-of-type {
+    margin-top: 0; }
 
 @media screen and (min-width: 480px) {
   .f100-ns {
@@ -19931,7 +20003,6 @@ Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy do
     font-size: 1.33333rem;
     line-height: 1.3333333333333333; }
   .f700-ns {
-    color: red;
     font-size: 1.77778rem;
     line-height: 1.25; }
   .f800-ns {
@@ -19970,7 +20041,6 @@ Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy do
     font-size: 1.33333rem;
     line-height: 1.3333333333333333; }
   .f700-m {
-    color: red;
     font-size: 1.77778rem;
     line-height: 1.25; }
   .f800-m {
@@ -20009,7 +20079,6 @@ Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy do
     font-size: 1.33333rem;
     line-height: 1.3333333333333333; }
   .f700-l {
-    color: red;
     font-size: 1.77778rem;
     line-height: 1.25; }
   .f800-l {

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -19910,6 +19910,35 @@ Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy do
   font-size: 7.5rem;
   line-height: 0.928395061728395; }
 
+section#type-scale .db {
+  margin-top: 3.0rem; }
+  section#type-scale .db:first-of-type {
+    margin-top: 0; }
+
+.f100 {
+  font-size: 0.61111rem;
+  line-height: 1.696969696969697; }
+
+.f200 {
+  font-size: 0.72222rem;
+  line-height: 1.641025641025641; }
+
+.f300 {
+  font-size: 0.88889rem;
+  line-height: 1.5; }
+
+.f400 {
+  font-size: 1rem;
+  line-height: 1.4814814814814816; }
+
+.f500 {
+  font-size: 1.16667rem;
+  line-height: 1.3968253968253967; }
+
+html:not(.legacy-type-scale) .f600 {
+  font-size: 1.33333rem;
+  line-height: 1.3333333333333333; }
+
 html.legacy-type-scale .f600 {
   font-size: 1.16667rem;
   line-height: 1.3968253968253967; }
@@ -19917,6 +19946,10 @@ html.legacy-type-scale .f600 {
     html.legacy-type-scale .f600 {
       font-size: 1.33333rem;
       line-height: 1.3333333333333333; } }
+
+html:not(.legacy-type-scale) .f700 {
+  font-size: 1.77778rem;
+  line-height: 1.25; }
 
 html.legacy-type-scale .f700 {
   font-size: 1.33333rem;
@@ -19926,6 +19959,10 @@ html.legacy-type-scale .f700 {
       font-size: 1.77778rem;
       line-height: 1.25; } }
 
+html:not(.legacy-type-scale) .f800 {
+  font-size: 2.38889rem;
+  line-height: 1.1782945736434107; }
+
 html.legacy-type-scale .f800 {
   font-size: 1.77778rem;
   line-height: 1.25; }
@@ -19934,6 +19971,10 @@ html.legacy-type-scale .f800 {
       font-size: 2.38889rem;
       line-height: 1.1782945736434107; } }
 
+html:not(.legacy-type-scale) .f900 {
+  font-size: 3.16667rem;
+  line-height: 1.1228070175438596; }
+
 html.legacy-type-scale .f900 {
   font-size: 2.38889rem;
   line-height: 1.1782945736434107; }
@@ -19941,6 +19982,10 @@ html.legacy-type-scale .f900 {
     html.legacy-type-scale .f900 {
       font-size: 3.16667rem;
       line-height: 1.1228070175438596; } }
+
+html:not(.legacy-type-scale) .f1000 {
+  font-size: 4.22222rem;
+  line-height: 1.0526315789473684; }
 
 html.legacy-type-scale .f1000 {
   font-size: 2.38889rem;
@@ -19954,6 +19999,10 @@ html.legacy-type-scale .f1000 {
       font-size: 4.22222rem;
       line-height: 1.0526315789473684; } }
 
+html:not(.legacy-type-scale) .f1100 {
+  font-size: 5.61111rem;
+  line-height: 0.9703; }
+
 html.legacy-type-scale .f1100 {
   font-size: 3.16667rem;
   line-height: 1.1228070175438596; }
@@ -19966,6 +20015,10 @@ html.legacy-type-scale .f1100 {
       font-size: 5.61111rem;
       line-height: 1.0033003300330032; } }
 
+html:not(.legacy-type-scale) .f1200 {
+  font-size: 7.5rem;
+  line-height: 1.00741; }
+
 html.legacy-type-scale .f1200 {
   font-size: 3.16667rem;
   line-height: 1.1228070175438596; }
@@ -19977,11 +20030,6 @@ html.legacy-type-scale .f1200 {
     html.legacy-type-scale .f1200 {
       font-size: 7.5rem;
       line-height: 0.928395061728395; } }
-
-section#type-scale div.db {
-  margin-top: 3.0rem; }
-  section#type-scale div.db:first-of-type {
-    margin-top: 0; }
 
 @media screen and (min-width: 480px) {
   .f100-ns {
@@ -19999,27 +20047,100 @@ section#type-scale div.db {
   .f500-ns {
     font-size: 1.16667rem;
     line-height: 1.3968253968253967; }
-  .f600-ns {
+  html:not(.legacy-type-scale) .f600-ns {
     font-size: 1.33333rem;
     line-height: 1.3333333333333333; }
-  .f700-ns {
+  html.legacy-type-scale .f600-ns {
+    font-size: 1.16667rem;
+    line-height: 1.3968253968253967; } }
+  @media screen and (min-width: 480px) and (min-width: 480px) {
+    html.legacy-type-scale .f600-ns {
+      font-size: 1.33333rem;
+      line-height: 1.3333333333333333; } }
+
+@media screen and (min-width: 480px) {
+  html:not(.legacy-type-scale) .f700-ns {
     font-size: 1.77778rem;
     line-height: 1.25; }
-  .f800-ns {
+  html.legacy-type-scale .f700-ns {
+    font-size: 1.33333rem;
+    line-height: 1.3333333333333333; } }
+  @media screen and (min-width: 480px) and (min-width: 480px) {
+    html.legacy-type-scale .f700-ns {
+      font-size: 1.77778rem;
+      line-height: 1.25; } }
+
+@media screen and (min-width: 480px) {
+  html:not(.legacy-type-scale) .f800-ns {
     font-size: 2.38889rem;
     line-height: 1.1782945736434107; }
-  .f900-ns {
+  html.legacy-type-scale .f800-ns {
+    font-size: 1.77778rem;
+    line-height: 1.25; } }
+  @media screen and (min-width: 480px) and (min-width: 480px) {
+    html.legacy-type-scale .f800-ns {
+      font-size: 2.38889rem;
+      line-height: 1.1782945736434107; } }
+
+@media screen and (min-width: 480px) {
+  html:not(.legacy-type-scale) .f900-ns {
     font-size: 3.16667rem;
     line-height: 1.1228070175438596; }
-  .f1000-ns {
+  html.legacy-type-scale .f900-ns {
+    font-size: 2.38889rem;
+    line-height: 1.1782945736434107; } }
+  @media screen and (min-width: 480px) and (min-width: 480px) {
+    html.legacy-type-scale .f900-ns {
+      font-size: 3.16667rem;
+      line-height: 1.1228070175438596; } }
+
+@media screen and (min-width: 480px) {
+  html:not(.legacy-type-scale) .f1000-ns {
     font-size: 4.22222rem;
     line-height: 1.0526315789473684; }
-  .f1100-ns {
+  html.legacy-type-scale .f1000-ns {
+    font-size: 2.38889rem;
+    line-height: 1.1782945736434107; } }
+  @media screen and (min-width: 480px) and (min-width: 480px) {
+    html.legacy-type-scale .f1000-ns {
+      font-size: 3.16667rem;
+      line-height: 1.1228070175438596; } }
+  @media screen and (min-width: 480px) and (min-width: 480px) {
+    html.legacy-type-scale .f1000-ns {
+      font-size: 4.22222rem;
+      line-height: 1.0526315789473684; } }
+
+@media screen and (min-width: 480px) {
+  html:not(.legacy-type-scale) .f1100-ns {
     font-size: 5.61111rem;
     line-height: 0.9703; }
-  .f1200-ns {
+  html.legacy-type-scale .f1100-ns {
+    font-size: 3.16667rem;
+    line-height: 1.1228070175438596; } }
+  @media screen and (min-width: 480px) and (min-width: 480px) and (max-width: 959px) {
+    html.legacy-type-scale .f1100-ns {
+      font-size: 4.22222rem;
+      line-height: 1.0526315789473684; } }
+  @media screen and (min-width: 480px) and (min-width: 960px) {
+    html.legacy-type-scale .f1100-ns {
+      font-size: 5.61111rem;
+      line-height: 1.0033003300330032; } }
+
+@media screen and (min-width: 480px) {
+  html:not(.legacy-type-scale) .f1200-ns {
     font-size: 7.5rem;
-    line-height: 1.00741; } }
+    line-height: 1.00741; }
+  html.legacy-type-scale .f1200-ns {
+    font-size: 3.16667rem;
+    line-height: 1.1228070175438596; } }
+  @media screen and (min-width: 480px) and (min-width: 480px) and (max-width: 959px) {
+    html.legacy-type-scale .f1200-ns {
+      font-size: 4.22222rem;
+      line-height: 1.0526315789473684; } }
+  @media screen and (min-width: 480px) and (min-width: 960px) {
+    html.legacy-type-scale .f1200-ns {
+      font-size: 7.5rem;
+      line-height: 0.928395061728395; } }
 
 @media screen and (min-width: 480px) and (max-width: 959px) {
   .f100-m {
@@ -20037,27 +20158,100 @@ section#type-scale div.db {
   .f500-m {
     font-size: 1.16667rem;
     line-height: 1.3968253968253967; }
-  .f600-m {
+  html:not(.legacy-type-scale) .f600-m {
     font-size: 1.33333rem;
     line-height: 1.3333333333333333; }
-  .f700-m {
+  html.legacy-type-scale .f600-m {
+    font-size: 1.16667rem;
+    line-height: 1.3968253968253967; } }
+  @media screen and (min-width: 480px) and (max-width: 959px) and (min-width: 480px) {
+    html.legacy-type-scale .f600-m {
+      font-size: 1.33333rem;
+      line-height: 1.3333333333333333; } }
+
+@media screen and (min-width: 480px) and (max-width: 959px) {
+  html:not(.legacy-type-scale) .f700-m {
     font-size: 1.77778rem;
     line-height: 1.25; }
-  .f800-m {
+  html.legacy-type-scale .f700-m {
+    font-size: 1.33333rem;
+    line-height: 1.3333333333333333; } }
+  @media screen and (min-width: 480px) and (max-width: 959px) and (min-width: 480px) {
+    html.legacy-type-scale .f700-m {
+      font-size: 1.77778rem;
+      line-height: 1.25; } }
+
+@media screen and (min-width: 480px) and (max-width: 959px) {
+  html:not(.legacy-type-scale) .f800-m {
     font-size: 2.38889rem;
     line-height: 1.1782945736434107; }
-  .f900-m {
+  html.legacy-type-scale .f800-m {
+    font-size: 1.77778rem;
+    line-height: 1.25; } }
+  @media screen and (min-width: 480px) and (max-width: 959px) and (min-width: 480px) {
+    html.legacy-type-scale .f800-m {
+      font-size: 2.38889rem;
+      line-height: 1.1782945736434107; } }
+
+@media screen and (min-width: 480px) and (max-width: 959px) {
+  html:not(.legacy-type-scale) .f900-m {
     font-size: 3.16667rem;
     line-height: 1.1228070175438596; }
-  .f1000-m {
+  html.legacy-type-scale .f900-m {
+    font-size: 2.38889rem;
+    line-height: 1.1782945736434107; } }
+  @media screen and (min-width: 480px) and (max-width: 959px) and (min-width: 480px) {
+    html.legacy-type-scale .f900-m {
+      font-size: 3.16667rem;
+      line-height: 1.1228070175438596; } }
+
+@media screen and (min-width: 480px) and (max-width: 959px) {
+  html:not(.legacy-type-scale) .f1000-m {
     font-size: 4.22222rem;
     line-height: 1.0526315789473684; }
-  .f1100-m {
+  html.legacy-type-scale .f1000-m {
+    font-size: 2.38889rem;
+    line-height: 1.1782945736434107; } }
+  @media screen and (min-width: 480px) and (max-width: 959px) and (min-width: 480px) {
+    html.legacy-type-scale .f1000-m {
+      font-size: 3.16667rem;
+      line-height: 1.1228070175438596; } }
+  @media screen and (min-width: 480px) and (max-width: 959px) and (min-width: 480px) {
+    html.legacy-type-scale .f1000-m {
+      font-size: 4.22222rem;
+      line-height: 1.0526315789473684; } }
+
+@media screen and (min-width: 480px) and (max-width: 959px) {
+  html:not(.legacy-type-scale) .f1100-m {
     font-size: 5.61111rem;
     line-height: 0.9703; }
-  .f1200-m {
+  html.legacy-type-scale .f1100-m {
+    font-size: 3.16667rem;
+    line-height: 1.1228070175438596; } }
+  @media screen and (min-width: 480px) and (max-width: 959px) and (min-width: 480px) and (max-width: 959px) {
+    html.legacy-type-scale .f1100-m {
+      font-size: 4.22222rem;
+      line-height: 1.0526315789473684; } }
+  @media screen and (min-width: 480px) and (max-width: 959px) and (min-width: 960px) {
+    html.legacy-type-scale .f1100-m {
+      font-size: 5.61111rem;
+      line-height: 1.0033003300330032; } }
+
+@media screen and (min-width: 480px) and (max-width: 959px) {
+  html:not(.legacy-type-scale) .f1200-m {
     font-size: 7.5rem;
-    line-height: 1.00741; } }
+    line-height: 1.00741; }
+  html.legacy-type-scale .f1200-m {
+    font-size: 3.16667rem;
+    line-height: 1.1228070175438596; } }
+  @media screen and (min-width: 480px) and (max-width: 959px) and (min-width: 480px) and (max-width: 959px) {
+    html.legacy-type-scale .f1200-m {
+      font-size: 4.22222rem;
+      line-height: 1.0526315789473684; } }
+  @media screen and (min-width: 480px) and (max-width: 959px) and (min-width: 960px) {
+    html.legacy-type-scale .f1200-m {
+      font-size: 7.5rem;
+      line-height: 0.928395061728395; } }
 
 @media screen and (min-width: 960px) {
   .f100-l {
@@ -20075,27 +20269,100 @@ section#type-scale div.db {
   .f500-l {
     font-size: 1.16667rem;
     line-height: 1.3968253968253967; }
-  .f600-l {
+  html:not(.legacy-type-scale) .f600-l {
     font-size: 1.33333rem;
     line-height: 1.3333333333333333; }
-  .f700-l {
+  html.legacy-type-scale .f600-l {
+    font-size: 1.16667rem;
+    line-height: 1.3968253968253967; } }
+  @media screen and (min-width: 960px) and (min-width: 480px) {
+    html.legacy-type-scale .f600-l {
+      font-size: 1.33333rem;
+      line-height: 1.3333333333333333; } }
+
+@media screen and (min-width: 960px) {
+  html:not(.legacy-type-scale) .f700-l {
     font-size: 1.77778rem;
     line-height: 1.25; }
-  .f800-l {
+  html.legacy-type-scale .f700-l {
+    font-size: 1.33333rem;
+    line-height: 1.3333333333333333; } }
+  @media screen and (min-width: 960px) and (min-width: 480px) {
+    html.legacy-type-scale .f700-l {
+      font-size: 1.77778rem;
+      line-height: 1.25; } }
+
+@media screen and (min-width: 960px) {
+  html:not(.legacy-type-scale) .f800-l {
     font-size: 2.38889rem;
     line-height: 1.1782945736434107; }
-  .f900-l {
+  html.legacy-type-scale .f800-l {
+    font-size: 1.77778rem;
+    line-height: 1.25; } }
+  @media screen and (min-width: 960px) and (min-width: 480px) {
+    html.legacy-type-scale .f800-l {
+      font-size: 2.38889rem;
+      line-height: 1.1782945736434107; } }
+
+@media screen and (min-width: 960px) {
+  html:not(.legacy-type-scale) .f900-l {
     font-size: 3.16667rem;
     line-height: 1.1228070175438596; }
-  .f1000-l {
+  html.legacy-type-scale .f900-l {
+    font-size: 2.38889rem;
+    line-height: 1.1782945736434107; } }
+  @media screen and (min-width: 960px) and (min-width: 480px) {
+    html.legacy-type-scale .f900-l {
+      font-size: 3.16667rem;
+      line-height: 1.1228070175438596; } }
+
+@media screen and (min-width: 960px) {
+  html:not(.legacy-type-scale) .f1000-l {
     font-size: 4.22222rem;
     line-height: 1.0526315789473684; }
-  .f1100-l {
+  html.legacy-type-scale .f1000-l {
+    font-size: 2.38889rem;
+    line-height: 1.1782945736434107; } }
+  @media screen and (min-width: 960px) and (min-width: 480px) {
+    html.legacy-type-scale .f1000-l {
+      font-size: 3.16667rem;
+      line-height: 1.1228070175438596; } }
+  @media screen and (min-width: 960px) and (min-width: 480px) {
+    html.legacy-type-scale .f1000-l {
+      font-size: 4.22222rem;
+      line-height: 1.0526315789473684; } }
+
+@media screen and (min-width: 960px) {
+  html:not(.legacy-type-scale) .f1100-l {
     font-size: 5.61111rem;
     line-height: 0.9703; }
-  .f1200-l {
+  html.legacy-type-scale .f1100-l {
+    font-size: 3.16667rem;
+    line-height: 1.1228070175438596; } }
+  @media screen and (min-width: 960px) and (min-width: 480px) and (max-width: 959px) {
+    html.legacy-type-scale .f1100-l {
+      font-size: 4.22222rem;
+      line-height: 1.0526315789473684; } }
+  @media screen and (min-width: 960px) and (min-width: 960px) {
+    html.legacy-type-scale .f1100-l {
+      font-size: 5.61111rem;
+      line-height: 1.0033003300330032; } }
+
+@media screen and (min-width: 960px) {
+  html:not(.legacy-type-scale) .f1200-l {
     font-size: 7.5rem;
-    line-height: 1.00741; } }
+    line-height: 1.00741; }
+  html.legacy-type-scale .f1200-l {
+    font-size: 3.16667rem;
+    line-height: 1.1228070175438596; } }
+  @media screen and (min-width: 960px) and (min-width: 480px) and (max-width: 959px) {
+    html.legacy-type-scale .f1200-l {
+      font-size: 4.22222rem;
+      line-height: 1.0526315789473684; } }
+  @media screen and (min-width: 960px) and (min-width: 960px) {
+    html.legacy-type-scale .f1200-l {
+      font-size: 7.5rem;
+      line-height: 0.928395061728395; } }
 
 /*
 ---

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -19910,11 +19910,6 @@ Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy do
   font-size: 7.5rem;
   line-height: 0.928395061728395; }
 
-section#type-scale .db {
-  margin-top: 3.0rem; }
-  section#type-scale .db:first-of-type {
-    margin-top: 0; }
-
 .f100 {
   font-size: 0.61111rem;
   line-height: 1.696969696969697; }

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -19910,23 +19910,28 @@ Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy do
   font-size: 7.5rem;
   line-height: 0.928395061728395; }
 
-.f100 {
+html:not(.legacy-type-scale) .f100,
+html.legacy-type-scale .f100 {
   font-size: 0.61111rem;
   line-height: 1.696969696969697; }
 
-.f200 {
+html:not(.legacy-type-scale) .f200,
+html.legacy-type-scale .f200 {
   font-size: 0.72222rem;
   line-height: 1.641025641025641; }
 
-.f300 {
+html:not(.legacy-type-scale) .f300,
+html.legacy-type-scale .f300 {
   font-size: 0.88889rem;
   line-height: 1.5; }
 
-.f400 {
+html:not(.legacy-type-scale) .f400,
+html.legacy-type-scale .f400 {
   font-size: 1rem;
   line-height: 1.4814814814814816; }
 
-.f500 {
+html:not(.legacy-type-scale) .f500,
+html.legacy-type-scale .f500 {
   font-size: 1.16667rem;
   line-height: 1.3968253968253967; }
 
@@ -20027,19 +20032,24 @@ html.legacy-type-scale .f1200 {
       line-height: 0.928395061728395; } }
 
 @media screen and (min-width: 480px) {
-  .f100-ns {
+  html:not(.legacy-type-scale) .f100-ns,
+  html.legacy-type-scale .f100-ns {
     font-size: 0.61111rem;
     line-height: 1.696969696969697; }
-  .f200-ns {
+  html:not(.legacy-type-scale) .f200-ns,
+  html.legacy-type-scale .f200-ns {
     font-size: 0.72222rem;
     line-height: 1.641025641025641; }
-  .f300-ns {
+  html:not(.legacy-type-scale) .f300-ns,
+  html.legacy-type-scale .f300-ns {
     font-size: 0.88889rem;
     line-height: 1.5; }
-  .f400-ns {
+  html:not(.legacy-type-scale) .f400-ns,
+  html.legacy-type-scale .f400-ns {
     font-size: 1rem;
     line-height: 1.4814814814814816; }
-  .f500-ns {
+  html:not(.legacy-type-scale) .f500-ns,
+  html.legacy-type-scale .f500-ns {
     font-size: 1.16667rem;
     line-height: 1.3968253968253967; }
   html:not(.legacy-type-scale) .f600-ns {
@@ -20138,19 +20148,24 @@ html.legacy-type-scale .f1200 {
       line-height: 0.928395061728395; } }
 
 @media screen and (min-width: 480px) and (max-width: 959px) {
-  .f100-m {
+  html:not(.legacy-type-scale) .f100-m,
+  html.legacy-type-scale .f100-m {
     font-size: 0.61111rem;
     line-height: 1.696969696969697; }
-  .f200-m {
+  html:not(.legacy-type-scale) .f200-m,
+  html.legacy-type-scale .f200-m {
     font-size: 0.72222rem;
     line-height: 1.641025641025641; }
-  .f300-m {
+  html:not(.legacy-type-scale) .f300-m,
+  html.legacy-type-scale .f300-m {
     font-size: 0.88889rem;
     line-height: 1.5; }
-  .f400-m {
+  html:not(.legacy-type-scale) .f400-m,
+  html.legacy-type-scale .f400-m {
     font-size: 1rem;
     line-height: 1.4814814814814816; }
-  .f500-m {
+  html:not(.legacy-type-scale) .f500-m,
+  html.legacy-type-scale .f500-m {
     font-size: 1.16667rem;
     line-height: 1.3968253968253967; }
   html:not(.legacy-type-scale) .f600-m {
@@ -20249,19 +20264,24 @@ html.legacy-type-scale .f1200 {
       line-height: 0.928395061728395; } }
 
 @media screen and (min-width: 960px) {
-  .f100-l {
+  html:not(.legacy-type-scale) .f100-l,
+  html.legacy-type-scale .f100-l {
     font-size: 0.61111rem;
     line-height: 1.696969696969697; }
-  .f200-l {
+  html:not(.legacy-type-scale) .f200-l,
+  html.legacy-type-scale .f200-l {
     font-size: 0.72222rem;
     line-height: 1.641025641025641; }
-  .f300-l {
+  html:not(.legacy-type-scale) .f300-l,
+  html.legacy-type-scale .f300-l {
     font-size: 0.88889rem;
     line-height: 1.5; }
-  .f400-l {
+  html:not(.legacy-type-scale) .f400-l,
+  html.legacy-type-scale .f400-l {
     font-size: 1rem;
     line-height: 1.4814814814814816; }
-  .f500-l {
+  html:not(.legacy-type-scale) .f500-l,
+  html.legacy-type-scale .f500-l {
     font-size: 1.16667rem;
     line-height: 1.3968253968253967; }
   html:not(.legacy-type-scale) .f600-l {

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -19883,72 +19883,33 @@ Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy do
   line-height: 1.3968253968253967; }
 
 .f600 {
-  font-size: 1.16667rem;
-  line-height: 1.3968253968253967; }
-  @media screen and (min-width: 480px) {
-    .f600 {
-      font-size: 1.33333rem;
-      line-height: 1.3333333333333333; } }
-
-.f700 {
   font-size: 1.33333rem;
   line-height: 1.3333333333333333; }
-  @media screen and (min-width: 480px) {
-    .f700 {
-      font-size: 1.77778rem;
-      line-height: 1.25; } }
 
-.f800 {
+.f700 {
+  color: red;
   font-size: 1.77778rem;
   line-height: 1.25; }
-  @media screen and (min-width: 480px) {
-    .f800 {
-      font-size: 2.38889rem;
-      line-height: 1.1782945736434107; } }
+
+.f800 {
+  font-size: 2.38889rem;
+  line-height: 1.1782945736434107; }
 
 .f900 {
-  font-size: 2.38889rem;
-  line-height: 1.1782945736434107; }
-  @media screen and (min-width: 480px) {
-    .f900 {
-      font-size: 3.16667rem;
-      line-height: 1.1228070175438596; } }
+  font-size: 3.16667rem;
+  line-height: 1.1228070175438596; }
 
 .f1000 {
-  font-size: 2.38889rem;
-  line-height: 1.1782945736434107; }
-  @media screen and (min-width: 480px) {
-    .f1000 {
-      font-size: 3.16667rem;
-      line-height: 1.1228070175438596; } }
-  @media screen and (min-width: 480px) {
-    .f1000 {
-      font-size: 4.22222rem;
-      line-height: 1.0526315789473684; } }
+  font-size: 3.16667rem;
+  line-height: 1.1228070175438596; }
 
 .f1100 {
-  font-size: 3.16667rem;
-  line-height: 1.1228070175438596; }
-  @media screen and (min-width: 480px) and (max-width: 959px) {
-    .f1100 {
-      font-size: 4.22222rem;
-      line-height: 1.0526315789473684; } }
-  @media screen and (min-width: 960px) {
-    .f1100 {
-      font-size: 5.61111rem;
-      line-height: 1.0033003300330032; } }
+  font-size: 5.61111rem;
+  line-height: 1.0033003300330032; }
 
 .f1200 {
-  font-size: 3.16667rem;
-  line-height: 1.1228070175438596; }
-  @media screen and (min-width: 480px) and (max-width: 959px) {
-    .f1200 {
-      font-size: 4.22222rem;
-      line-height: 1.0526315789473684; } }
-  @media screen and (min-width: 960px) {
-    .f1200 {
-      font-size: 7.5rem;
-      line-height: 0.928395061728395; } }
+  font-size: 7.5rem;
+  line-height: 0.928395061728395; }
 
 @media screen and (min-width: 480px) {
   .f100-ns {
@@ -19970,6 +19931,7 @@ Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy do
     font-size: 1.33333rem;
     line-height: 1.3333333333333333; }
   .f700-ns {
+    color: red;
     font-size: 1.77778rem;
     line-height: 1.25; }
   .f800-ns {
@@ -20008,6 +19970,7 @@ Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy do
     font-size: 1.33333rem;
     line-height: 1.3333333333333333; }
   .f700-m {
+    color: red;
     font-size: 1.77778rem;
     line-height: 1.25; }
   .f800-m {
@@ -20046,6 +20009,7 @@ Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy do
     font-size: 1.33333rem;
     line-height: 1.3333333333333333; }
   .f700-l {
+    color: red;
     font-size: 1.77778rem;
     line-height: 1.25; }
   .f800-l {

--- a/packets/seedlings/src/_type-scale.scss
+++ b/packets/seedlings/src/_type-scale.scss
@@ -73,6 +73,32 @@ Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy do
 .f1200 {
   @include f1200;
 }
+
+// Legacy Type Scale Includes
+html.legacy-type-scale {
+  .f600 {
+    @include f600--legacy;
+  }
+  .f700 {
+    @include f700--legacy;
+  }
+  .f800 {
+    @include f800--legacy;
+  }
+  .f900 {
+    @include f900--legacy;
+  }
+  .f1000 {
+    @include f1000--legacy;
+  }
+  .f1100 {
+    @include f1100--legacy;
+  }
+  .f1200 {
+    @include f1200--legacy;
+  }
+}
+
 @mixin type-scale($breakpoint-name: "") {
   // We can't interpolate the name of the mixin, so we have to write out each class :/
   .f100#{$breakpoint-name} {

--- a/packets/seedlings/src/_type-scale.scss
+++ b/packets/seedlings/src/_type-scale.scss
@@ -77,19 +77,34 @@ Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy do
 @mixin type-scale($breakpoint-name: "") {
   // We can't interpolate the name of the mixin, so we have to write out each class :/
   .f100#{$breakpoint-name} {
-    @include Typography-size--100;
+    html:not(.legacy-type-scale) &,
+    html.legacy-type-scale & {
+      @include Typography-size--100;
+    }
   }
   .f200#{$breakpoint-name} {
-    @include Typography-size--200;
+    html:not(.legacy-type-scale) &,
+    html.legacy-type-scale & {
+      @include Typography-size--200;
+    }
   }
   .f300#{$breakpoint-name} {
-    @include Typography-size--300;
+    html:not(.legacy-type-scale) &,
+    html.legacy-type-scale & {
+      @include Typography-size--300;
+    }
   }
   .f400#{$breakpoint-name} {
-    @include Typography-size--400;
+    html:not(.legacy-type-scale) &,
+    html.legacy-type-scale & {
+      @include Typography-size--400;
+    }
   }
   .f500#{$breakpoint-name} {
-    @include Typography-size--500;
+    html:not(.legacy-type-scale) &,
+    html.legacy-type-scale & {
+      @include Typography-size--500;
+    }
   }
   .f600#{$breakpoint-name} {
     html:not(.legacy-type-scale) & {

--- a/packets/seedlings/src/_type-scale.scss
+++ b/packets/seedlings/src/_type-scale.scss
@@ -74,31 +74,6 @@ Example: <div class="db {{modifier}}">The quick brown fox jumps over the lazy do
   @include f1200;
 }
 
-// Legacy Type Scale Includes
-html.legacy-type-scale {
-  .f600 {
-    @include f600--legacy;
-  }
-  .f700 {
-    @include f700--legacy;
-  }
-  .f800 {
-    @include f800--legacy;
-  }
-  .f900 {
-    @include f900--legacy;
-  }
-  .f1000 {
-    @include f1000--legacy;
-  }
-  .f1100 {
-    @include f1100--legacy;
-  }
-  .f1200 {
-    @include f1200--legacy;
-  }
-}
-
 @mixin type-scale($breakpoint-name: "") {
   // We can't interpolate the name of the mixin, so we have to write out each class :/
   .f100#{$breakpoint-name} {
@@ -117,27 +92,92 @@ html.legacy-type-scale {
     @include Typography-size--500;
   }
   .f600#{$breakpoint-name} {
-    @include Typography-size--600;
+    html:not(.legacy-type-scale) & {
+      @include Typography-size--600;
+    }
+    html.legacy-type-scale & {
+      @include Typography-size--500;
+      @media #{$breakpoint-not-small} {
+        @include Typography-size--600;
+      }
+    }
   }
   .f700#{$breakpoint-name} {
-    @include Typography-size--700;
+    html:not(.legacy-type-scale) & {
+      @include Typography-size--700;
+    }
+    html.legacy-type-scale & {
+      @include Typography-size--600;
+      @media #{$breakpoint-not-small} {
+        @include Typography-size--700;
+      }
+    }
   }
   .f800#{$breakpoint-name} {
-    @include Typography-size--800;
+    html:not(.legacy-type-scale) & {
+      @include Typography-size--800;
+    }
+    html.legacy-type-scale & {
+      @include Typography-size--700;
+      @media #{$breakpoint-not-small} {
+        @include Typography-size--800;
+      }
+    }
   }
   .f900#{$breakpoint-name} {
-    @include Typography-size--900;
+    html:not(.legacy-type-scale) & {
+      @include Typography-size--900;
+    }
+    html.legacy-type-scale & {
+      @include Typography-size--800;
+      @media #{$breakpoint-not-small} {
+        @include Typography-size--900;
+      }
+    }
   }
   .f1000#{$breakpoint-name} {
-    @include Typography-size--1000;
+    html:not(.legacy-type-scale) & {
+      @include Typography-size--1000;
+    }
+    html.legacy-type-scale & {
+      @include Typography-size--800;
+      @media #{$breakpoint-not-small} {
+        @include Typography-size--900;
+      }
+      @media #{$breakpoint-not-small} {
+        @include Typography-size--1000;
+      }
+    }
   }
   .f1100#{$breakpoint-name} {
-    font-size: setUnits(101px);
-    line-height: #{(98/101)};
+    html:not(.legacy-type-scale) & {
+      font-size: setUnits(101px);
+      line-height: #{(98/101)};
+    }
+    html.legacy-type-scale & {
+      @include Typography-size--900;
+      @media #{$breakpoint-medium} {
+        @include Typography-size--1000;
+      }
+      @media #{$breakpoint-large} {
+        @include Typography-size--1100;
+      }
+    }
   }
   .f1200#{$breakpoint-name} {
-    font-size: setUnits(135px);
-    line-height: #{(136/135)};
+    html:not(.legacy-type-scale) & {
+      font-size: setUnits(135px);
+      line-height: #{(136/135)};
+    }
+    html.legacy-type-scale & {
+      @include Typography-size--900;
+      @media #{$breakpoint-medium} {
+        @include Typography-size--1000;
+      }
+      @media #{$breakpoint-large} {
+        @include Typography-size--1200;
+      }
+    }
   }
 }
 @each $breakpoint-name, $breakpoint in $breakpoints {
@@ -145,5 +185,7 @@ html.legacy-type-scale {
     @media #{$breakpoint} {
       @include type-scale($breakpoint-name);
     }
+  } @else {
+    @include type-scale;
   }
 }

--- a/packets/seedlings/src/axioms/TypeScale.scss
+++ b/packets/seedlings/src/axioms/TypeScale.scss
@@ -48,38 +48,3 @@
 @mixin f1200 {
   @include Typography-size--1200;
 }
-
-// Legacy Type Scale Mixins
-// @mixin f900--legacy {
-//   @include Typography-size--800;
-//   @media #{$breakpoint-not-small} {
-//     @include Typography-size--900;
-//   }
-// }
-// @mixin f1000--legacy {
-//   @include Typography-size--800;
-//   @media #{$breakpoint-not-small} {
-//     @include Typography-size--900;
-//   }
-//   @media #{$breakpoint-not-small} {
-//     @include Typography-size--1000;
-//   }
-// }
-// @mixin f1100--legacy {
-//   @include Typography-size--900;
-//   @media #{$breakpoint-medium} {
-//     @include Typography-size--1000;
-//   }
-//   @media #{$breakpoint-large} {
-//     @include Typography-size--1100;
-//   }
-// }
-// @mixin f1200--legacy {
-//   @include Typography-size--900;
-//   @media #{$breakpoint-medium} {
-//     @include Typography-size--1000;
-//   }
-//   @media #{$breakpoint-large} {
-//     @include Typography-size--1200;
-//   }
-// }

--- a/packets/seedlings/src/axioms/TypeScale.scss
+++ b/packets/seedlings/src/axioms/TypeScale.scss
@@ -28,53 +28,23 @@
   @include Typography-size--500;
 }
 @mixin f600 {
-  @include Typography-size--500;
-  @media #{$breakpoint-not-small} {
-    @include Typography-size--600;
-  }
+  @include Typography-size--600;
 }
 @mixin f700 {
-  @include Typography-size--600;
-  @media #{$breakpoint-not-small} {
-    @include Typography-size--700;
-  }
+  @include Typography-size--700;
 }
 @mixin f800 {
-  @include Typography-size--700;
-  @media #{$breakpoint-not-small} {
-    @include Typography-size--800;
-  }
+  @include Typography-size--800;
 }
 @mixin f900 {
-  @include Typography-size--800;
-  @media #{$breakpoint-not-small} {
-    @include Typography-size--900;
-  }
+  @include Typography-size--900;
 }
 @mixin f1000 {
-  @include Typography-size--800;
-  @media #{$breakpoint-not-small} {
-    @include Typography-size--900;
-  }
-  @media #{$breakpoint-not-small} {
-    @include Typography-size--1000;
-  }
+  @include Typography-size--900;
 }
 @mixin f1100 {
-  @include Typography-size--900;
-  @media #{$breakpoint-medium} {
-    @include Typography-size--1000;
-  }
-  @media #{$breakpoint-large} {
-    @include Typography-size--1100;
-  }
+  @include Typography-size--1100;
 }
 @mixin f1200 {
-  @include Typography-size--900;
-  @media #{$breakpoint-medium} {
-    @include Typography-size--1000;
-  }
-  @media #{$breakpoint-large} {
-    @include Typography-size--1200;
-  }
+  @include Typography-size--1200;
 }

--- a/packets/seedlings/src/axioms/TypeScale.scss
+++ b/packets/seedlings/src/axioms/TypeScale.scss
@@ -40,11 +40,64 @@
   @include Typography-size--900;
 }
 @mixin f1000 {
-  @include Typography-size--900;
+  @include Typography-size--1000;
 }
 @mixin f1100 {
   @include Typography-size--1100;
 }
 @mixin f1200 {
   @include Typography-size--1200;
+}
+
+// Legacy Type Scale Mixins
+@mixin f600--legacy {
+  @include Typography-size--500;
+  @media #{$breakpoint-not-small} {
+    @include Typography-size--600;
+  }
+}
+@mixin f700--legacy {
+  @include Typography-size--600;
+  @media #{$breakpoint-not-small} {
+    @include Typography-size--700;
+  }
+}
+@mixin f800--legacy {
+  @include Typography-size--700;
+  @media #{$breakpoint-not-small} {
+    @include Typography-size--800;
+  }
+}
+@mixin f900--legacy {
+  @include Typography-size--800;
+  @media #{$breakpoint-not-small} {
+    @include Typography-size--900;
+  }
+}
+@mixin f1000--legacy {
+  @include Typography-size--800;
+  @media #{$breakpoint-not-small} {
+    @include Typography-size--900;
+  }
+  @media #{$breakpoint-not-small} {
+    @include Typography-size--1000;
+  }
+}
+@mixin f1100--legacy {
+  @include Typography-size--900;
+  @media #{$breakpoint-medium} {
+    @include Typography-size--1000;
+  }
+  @media #{$breakpoint-large} {
+    @include Typography-size--1100;
+  }
+}
+@mixin f1200--legacy {
+  @include Typography-size--900;
+  @media #{$breakpoint-medium} {
+    @include Typography-size--1000;
+  }
+  @media #{$breakpoint-large} {
+    @include Typography-size--1200;
+  }
 }

--- a/packets/seedlings/src/axioms/TypeScale.scss
+++ b/packets/seedlings/src/axioms/TypeScale.scss
@@ -50,54 +50,36 @@
 }
 
 // Legacy Type Scale Mixins
-@mixin f600--legacy {
-  @include Typography-size--500;
-  @media #{$breakpoint-not-small} {
-    @include Typography-size--600;
-  }
-}
-@mixin f700--legacy {
-  @include Typography-size--600;
-  @media #{$breakpoint-not-small} {
-    @include Typography-size--700;
-  }
-}
-@mixin f800--legacy {
-  @include Typography-size--700;
-  @media #{$breakpoint-not-small} {
-    @include Typography-size--800;
-  }
-}
-@mixin f900--legacy {
-  @include Typography-size--800;
-  @media #{$breakpoint-not-small} {
-    @include Typography-size--900;
-  }
-}
-@mixin f1000--legacy {
-  @include Typography-size--800;
-  @media #{$breakpoint-not-small} {
-    @include Typography-size--900;
-  }
-  @media #{$breakpoint-not-small} {
-    @include Typography-size--1000;
-  }
-}
-@mixin f1100--legacy {
-  @include Typography-size--900;
-  @media #{$breakpoint-medium} {
-    @include Typography-size--1000;
-  }
-  @media #{$breakpoint-large} {
-    @include Typography-size--1100;
-  }
-}
-@mixin f1200--legacy {
-  @include Typography-size--900;
-  @media #{$breakpoint-medium} {
-    @include Typography-size--1000;
-  }
-  @media #{$breakpoint-large} {
-    @include Typography-size--1200;
-  }
-}
+// @mixin f900--legacy {
+//   @include Typography-size--800;
+//   @media #{$breakpoint-not-small} {
+//     @include Typography-size--900;
+//   }
+// }
+// @mixin f1000--legacy {
+//   @include Typography-size--800;
+//   @media #{$breakpoint-not-small} {
+//     @include Typography-size--900;
+//   }
+//   @media #{$breakpoint-not-small} {
+//     @include Typography-size--1000;
+//   }
+// }
+// @mixin f1100--legacy {
+//   @include Typography-size--900;
+//   @media #{$breakpoint-medium} {
+//     @include Typography-size--1000;
+//   }
+//   @media #{$breakpoint-large} {
+//     @include Typography-size--1100;
+//   }
+// }
+// @mixin f1200--legacy {
+//   @include Typography-size--900;
+//   @media #{$breakpoint-medium} {
+//     @include Typography-size--1000;
+//   }
+//   @media #{$breakpoint-large} {
+//     @include Typography-size--1200;
+//   }
+// }


### PR DESCRIPTION
## Details of Change

These changes in this Pull Request will make HTML headings (ex. `<h1></h1>`, `<h2></h3>`, `<h3></h3>`) apply sizing and spacing consistently across all viewport sizes for all pages going forward, while accommodating mobile- and tablet- viewport font size adjustments on pages currently in production.

To do this I have created a new ACF field in WordPress, called *Legacy Type Scale CSS*, which can be found within the *Page Options* panel:

![ACF Legacy Type Scale CSS Toggle within the WordPress backend, set to Yes/True/On](https://user-images.githubusercontent.com/18268037/158448089-87908b2b-a92e-40ca-b2df-3080a4f25ce9.png)

If this field is set to Yes/True, then that page will apply a `.legacy-type-scale` class to that page's `<html>` element. This will make the page abide by old type scale calculations. All pages in production will have this field set to Yes/True by default. Otherwise, all new pages should have this field set to No/False, allowing for the consistent type scales to be used.

## Relevant Links

- [Jira Card](https://sprout.atlassian.net/browse/MBC-7555?atlOrigin=eyJpIjoiZjUyMDVhOGU4OWVjNDUwMmE0Nzk0MTIwYTAwMWI2NjYiLCJwIjoiaiJ9)
- [Test Site](https://marketing-test.stagely.sproutsocial.com/)
  + [Best Example Page: Analytics and Social Listening Page](https://marketing-test.stagely.sproutsocial.com/analytics-and-social-listening/#features-solutions-carousel)


### Related PRs

- [PR #2913 in `sproutsocial/web-insights-application`](https://github.com/sproutsocial/web-insights-application/pull/2913)


## Steps to Test or Reproduce

1. Visit the [Analytics and Social Listening Page of test site](https://marketing-test.stagely.sproutsocial.com/analytics-and-social-listening/)
    - username: `admin`
    - password: `sprout4life`
2. Observe `legacy-type-scale` class applied to the `html` element on this pages (it can be found on other pages too)
3. Navigate to the [section of the page with the Features & Solutions Carousel](https://marketing-test.stagely.sproutsocial.com/analytics-and-social-listening/#features-solutions-carousel), with the heading, "Leverage data for transformative decision making"
4. Within this section, locate the `<h3>` header with the text "Track real-time results"
5. Because of the `legacy-type-scale` on this page's `<html>` element, this `<h3>` header will change its font size on mobile- and tablet- viewport sizes.
    - This demonstrates that old, legacy styles are being accommodated for these heading elements on pages that have opted into the Legacy Type Scales ACF field
4. If you remove the `legacy-type-scale` class from the `<html>` element (or toggle the Legacy Type Scale CSS ACF field to No/False on the WP backend for this page) and resize the viewport down to < `959px` wide, you'll see that that `<h3>` element will stay at `font-size: 21px;` and `line-height: 1.3968` across all viewport sizes
    - This demonstrates that heading elements on new pages that haven't opted into the Legacy Type Scales ACF field will abide by consistent type scales


## Browser testing

- [ ] Android Chrome
- [x] iOS Safari
- [x] macOS Chrome
- [x] macOS Firefox
- [x] macOS Safari
- [ ] Windows Chrome
- [ ] Windows Firefox
- [ ] Windows Edge
- [x] Screenreader


## Deploy Notes

Describe any important steps needed before deploying this updates like database changes or plugins needed.


## Todos

- [ ] Include any outstanding items here

