### PR TITLE
MBC-8079 - clean up seedlings theme colors

### DIFF
--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -1347,9 +1347,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
 .bg--main-dark {
   background-color: #008b46; }
 
-.bg--main-darkest {
-  background-color: #006b40; }
-
 .bg--text {
   background-color: #162020; }
 
@@ -1386,9 +1383,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
 .bg--background-inverse {
   background-color: #273333; }
 
-.bg--background-card {
-  background-color: #FFFFFF; }
-
 .bg--background-hero {
   background-color: #273333; }
 
@@ -1415,9 +1409,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
 
 .hover-bg--main-dark:hover {
   background-color: #008b46; }
-
-.hover-bg--main-darkest:hover {
-  background-color: #006b40; }
 
 .hover-bg--text:hover {
   background-color: #162020; }
@@ -1454,9 +1445,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
 
 .hover-bg--background-inverse:hover {
   background-color: #273333; }
-
-.hover-bg--background-card:hover {
-  background-color: #FFFFFF; }
 
 .hover-bg--background-hero:hover {
   background-color: #273333; }
@@ -2195,8 +2183,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #0ca750; }
   .bg--main-dark-ns {
     background-color: #008b46; }
-  .bg--main-darkest-ns {
-    background-color: #006b40; }
   .bg--text-ns {
     background-color: #162020; }
   .bg--text-light-ns {
@@ -2221,8 +2207,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #002838; }
   .bg--background-inverse-ns {
     background-color: #273333; }
-  .bg--background-card-ns {
-    background-color: #FFFFFF; }
   .bg--background-hero-ns {
     background-color: #273333; }
   .bg--background-hero-light-ns {
@@ -2241,8 +2225,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #0ca750; }
   .hover-bg--main-dark-ns:hover {
     background-color: #008b46; }
-  .hover-bg--main-darkest-ns:hover {
-    background-color: #006b40; }
   .hover-bg--text-ns:hover {
     background-color: #162020; }
   .hover-bg--text-light-ns:hover {
@@ -2267,8 +2249,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #002838; }
   .hover-bg--background-inverse-ns:hover {
     background-color: #273333; }
-  .hover-bg--background-card-ns:hover {
-    background-color: #FFFFFF; }
   .hover-bg--background-hero-ns:hover {
     background-color: #273333; }
   .hover-bg--background-hero-light-ns:hover {
@@ -2987,8 +2967,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #0ca750; }
   .bg--main-dark-m {
     background-color: #008b46; }
-  .bg--main-darkest-m {
-    background-color: #006b40; }
   .bg--text-m {
     background-color: #162020; }
   .bg--text-light-m {
@@ -3013,8 +2991,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #002838; }
   .bg--background-inverse-m {
     background-color: #273333; }
-  .bg--background-card-m {
-    background-color: #FFFFFF; }
   .bg--background-hero-m {
     background-color: #273333; }
   .bg--background-hero-light-m {
@@ -3033,8 +3009,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #0ca750; }
   .hover-bg--main-dark-m:hover {
     background-color: #008b46; }
-  .hover-bg--main-darkest-m:hover {
-    background-color: #006b40; }
   .hover-bg--text-m:hover {
     background-color: #162020; }
   .hover-bg--text-light-m:hover {
@@ -3059,8 +3033,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #002838; }
   .hover-bg--background-inverse-m:hover {
     background-color: #273333; }
-  .hover-bg--background-card-m:hover {
-    background-color: #FFFFFF; }
   .hover-bg--background-hero-m:hover {
     background-color: #273333; }
   .hover-bg--background-hero-light-m:hover {
@@ -3779,8 +3751,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #0ca750; }
   .bg--main-dark-l {
     background-color: #008b46; }
-  .bg--main-darkest-l {
-    background-color: #006b40; }
   .bg--text-l {
     background-color: #162020; }
   .bg--text-light-l {
@@ -3805,8 +3775,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #002838; }
   .bg--background-inverse-l {
     background-color: #273333; }
-  .bg--background-card-l {
-    background-color: #FFFFFF; }
   .bg--background-hero-l {
     background-color: #273333; }
   .bg--background-hero-light-l {
@@ -3825,8 +3793,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #0ca750; }
   .hover-bg--main-dark-l:hover {
     background-color: #008b46; }
-  .hover-bg--main-darkest-l:hover {
-    background-color: #006b40; }
   .hover-bg--text-l:hover {
     background-color: #162020; }
   .hover-bg--text-light-l:hover {
@@ -3851,8 +3817,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #002838; }
   .hover-bg--background-inverse-l:hover {
     background-color: #273333; }
-  .hover-bg--background-card-l:hover {
-    background-color: #FFFFFF; }
   .hover-bg--background-hero-l:hover {
     background-color: #273333; }
   .hover-bg--background-hero-light-l:hover {
@@ -4919,9 +4883,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
 .b--main-dark {
   border-color: #008b46; }
 
-.b--main-darkest {
-  border-color: #006b40; }
-
 .b--text {
   border-color: #162020; }
 
@@ -4958,9 +4919,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
 .b--background-inverse {
   border-color: #273333; }
 
-.b--background-card {
-  border-color: #FFFFFF; }
-
 .b--background-hero {
   border-color: #273333; }
 
@@ -4987,9 +4945,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
 
 .hover-b--main-dark:hover {
   border-color: #008b46; }
-
-.hover-b--main-darkest:hover {
-  border-color: #006b40; }
 
 .hover-b--text:hover {
   border-color: #162020; }
@@ -5026,9 +4981,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
 
 .hover-b--background-inverse:hover {
   border-color: #273333; }
-
-.hover-b--background-card:hover {
-  border-color: #FFFFFF; }
 
 .hover-b--background-hero:hover {
   border-color: #273333; }
@@ -5659,8 +5611,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #0ca750; }
   .b--main-dark-ns {
     border-color: #008b46; }
-  .b--main-darkest-ns {
-    border-color: #006b40; }
   .b--text-ns {
     border-color: #162020; }
   .b--text-light-ns {
@@ -5685,8 +5635,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #002838; }
   .b--background-inverse-ns {
     border-color: #273333; }
-  .b--background-card-ns {
-    border-color: #FFFFFF; }
   .b--background-hero-ns {
     border-color: #273333; }
   .b--background-hero-light-ns {
@@ -5705,8 +5653,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #0ca750; }
   .hover-b--main-dark-ns:hover {
     border-color: #008b46; }
-  .hover-b--main-darkest-ns:hover {
-    border-color: #006b40; }
   .hover-b--text-ns:hover {
     border-color: #162020; }
   .hover-b--text-light-ns:hover {
@@ -5731,8 +5677,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #002838; }
   .hover-b--background-inverse-ns:hover {
     border-color: #273333; }
-  .hover-b--background-card-ns:hover {
-    border-color: #FFFFFF; }
   .hover-b--background-hero-ns:hover {
     border-color: #273333; }
   .hover-b--background-hero-light-ns:hover {
@@ -6355,8 +6299,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #0ca750; }
   .b--main-dark-m {
     border-color: #008b46; }
-  .b--main-darkest-m {
-    border-color: #006b40; }
   .b--text-m {
     border-color: #162020; }
   .b--text-light-m {
@@ -6381,8 +6323,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #002838; }
   .b--background-inverse-m {
     border-color: #273333; }
-  .b--background-card-m {
-    border-color: #FFFFFF; }
   .b--background-hero-m {
     border-color: #273333; }
   .b--background-hero-light-m {
@@ -6401,8 +6341,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #0ca750; }
   .hover-b--main-dark-m:hover {
     border-color: #008b46; }
-  .hover-b--main-darkest-m:hover {
-    border-color: #006b40; }
   .hover-b--text-m:hover {
     border-color: #162020; }
   .hover-b--text-light-m:hover {
@@ -6427,8 +6365,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #002838; }
   .hover-b--background-inverse-m:hover {
     border-color: #273333; }
-  .hover-b--background-card-m:hover {
-    border-color: #FFFFFF; }
   .hover-b--background-hero-m:hover {
     border-color: #273333; }
   .hover-b--background-hero-light-m:hover {
@@ -7051,8 +6987,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #0ca750; }
   .b--main-dark-l {
     border-color: #008b46; }
-  .b--main-darkest-l {
-    border-color: #006b40; }
   .b--text-l {
     border-color: #162020; }
   .b--text-light-l {
@@ -7077,8 +7011,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #002838; }
   .b--background-inverse-l {
     border-color: #273333; }
-  .b--background-card-l {
-    border-color: #FFFFFF; }
   .b--background-hero-l {
     border-color: #273333; }
   .b--background-hero-light-l {
@@ -7097,8 +7029,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #0ca750; }
   .hover-b--main-dark-l:hover {
     border-color: #008b46; }
-  .hover-b--main-darkest-l:hover {
-    border-color: #006b40; }
   .hover-b--text-l:hover {
     border-color: #162020; }
   .hover-b--text-light-l:hover {
@@ -7123,8 +7053,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #002838; }
   .hover-b--background-inverse-l:hover {
     border-color: #273333; }
-  .hover-b--background-card-l:hover {
-    border-color: #FFFFFF; }
   .hover-b--background-hero-l:hover {
     border-color: #273333; }
   .hover-b--background-hero-light-l:hover {
@@ -8412,9 +8340,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
 .c--main-dark {
   color: #008b46; }
 
-.c--main-darkest {
-  color: #006b40; }
-
 .c--text {
   color: #162020; }
 
@@ -8451,9 +8376,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
 .c--background-inverse {
   color: #273333; }
 
-.c--background-card {
-  color: #FFFFFF; }
-
 .c--background-hero {
   color: #273333; }
 
@@ -8480,9 +8402,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
 
 .hover-c--main-dark:hover {
   color: #008b46; }
-
-.hover-c--main-darkest:hover {
-  color: #006b40; }
 
 .hover-c--text:hover {
   color: #162020; }
@@ -8519,9 +8438,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
 
 .hover-c--background-inverse:hover {
   color: #273333; }
-
-.hover-c--background-card:hover {
-  color: #FFFFFF; }
 
 .hover-c--background-hero:hover {
   color: #273333; }
@@ -9231,8 +9147,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #0ca750; }
   .c--main-dark-ns {
     color: #008b46; }
-  .c--main-darkest-ns {
-    color: #006b40; }
   .c--text-ns {
     color: #162020; }
   .c--text-light-ns {
@@ -9257,8 +9171,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #002838; }
   .c--background-inverse-ns {
     color: #273333; }
-  .c--background-card-ns {
-    color: #FFFFFF; }
   .c--background-hero-ns {
     color: #273333; }
   .c--background-hero-light-ns {
@@ -9277,8 +9189,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #0ca750; }
   .hover-c--main-dark-ns:hover {
     color: #008b46; }
-  .hover-c--main-darkest-ns:hover {
-    color: #006b40; }
   .hover-c--text-ns:hover {
     color: #162020; }
   .hover-c--text-light-ns:hover {
@@ -9303,8 +9213,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #002838; }
   .hover-c--background-inverse-ns:hover {
     color: #273333; }
-  .hover-c--background-card-ns:hover {
-    color: #FFFFFF; }
   .hover-c--background-hero-ns:hover {
     color: #273333; }
   .hover-c--background-hero-light-ns:hover {
@@ -10022,8 +9930,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #0ca750; }
   .c--main-dark-m {
     color: #008b46; }
-  .c--main-darkest-m {
-    color: #006b40; }
   .c--text-m {
     color: #162020; }
   .c--text-light-m {
@@ -10048,8 +9954,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #002838; }
   .c--background-inverse-m {
     color: #273333; }
-  .c--background-card-m {
-    color: #FFFFFF; }
   .c--background-hero-m {
     color: #273333; }
   .c--background-hero-light-m {
@@ -10068,8 +9972,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #0ca750; }
   .hover-c--main-dark-m:hover {
     color: #008b46; }
-  .hover-c--main-darkest-m:hover {
-    color: #006b40; }
   .hover-c--text-m:hover {
     color: #162020; }
   .hover-c--text-light-m:hover {
@@ -10094,8 +9996,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #002838; }
   .hover-c--background-inverse-m:hover {
     color: #273333; }
-  .hover-c--background-card-m:hover {
-    color: #FFFFFF; }
   .hover-c--background-hero-m:hover {
     color: #273333; }
   .hover-c--background-hero-light-m:hover {
@@ -10813,8 +10713,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #0ca750; }
   .c--main-dark-l {
     color: #008b46; }
-  .c--main-darkest-l {
-    color: #006b40; }
   .c--text-l {
     color: #162020; }
   .c--text-light-l {
@@ -10839,8 +10737,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #002838; }
   .c--background-inverse-l {
     color: #273333; }
-  .c--background-card-l {
-    color: #FFFFFF; }
   .c--background-hero-l {
     color: #273333; }
   .c--background-hero-light-l {
@@ -10859,8 +10755,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #0ca750; }
   .hover-c--main-dark-l:hover {
     color: #008b46; }
-  .hover-c--main-darkest-l:hover {
-    color: #006b40; }
   .hover-c--text-l:hover {
     color: #162020; }
   .hover-c--text-light-l:hover {
@@ -10885,8 +10779,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #002838; }
   .hover-c--background-inverse-l:hover {
     color: #273333; }
-  .hover-c--background-card-l:hover {
-    color: #FFFFFF; }
   .hover-c--background-hero-l:hover {
     color: #273333; }
   .hover-c--background-hero-light-l:hover {

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -1359,6 +1359,9 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
 .bg--text-inverse {
   background-color: #FFFFFF; }
 
+.bg--form-ui {
+  background-color: #1572BB; }
+
 .bg--link {
   background-color: #1572BB; }
 
@@ -1421,6 +1424,9 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
 
 .hover-bg--text-inverse:hover {
   background-color: #FFFFFF; }
+
+.hover-bg--form-ui:hover {
+  background-color: #1572BB; }
 
 .hover-bg--link:hover {
   background-color: #1572BB; }
@@ -2191,6 +2197,8 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #162020; }
   .bg--text-inverse-ns {
     background-color: #FFFFFF; }
+  .bg--form-ui-ns {
+    background-color: #1572BB; }
   .bg--link-ns {
     background-color: #1572BB; }
   .bg--link-dark-ns {
@@ -2233,6 +2241,8 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #162020; }
   .hover-bg--text-inverse-ns:hover {
     background-color: #FFFFFF; }
+  .hover-bg--form-ui-ns:hover {
+    background-color: #1572BB; }
   .hover-bg--link-ns:hover {
     background-color: #1572BB; }
   .hover-bg--link-dark-ns:hover {
@@ -2975,6 +2985,8 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #162020; }
   .bg--text-inverse-m {
     background-color: #FFFFFF; }
+  .bg--form-ui-m {
+    background-color: #1572BB; }
   .bg--link-m {
     background-color: #1572BB; }
   .bg--link-dark-m {
@@ -3017,6 +3029,8 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #162020; }
   .hover-bg--text-inverse-m:hover {
     background-color: #FFFFFF; }
+  .hover-bg--form-ui-m:hover {
+    background-color: #1572BB; }
   .hover-bg--link-m:hover {
     background-color: #1572BB; }
   .hover-bg--link-dark-m:hover {
@@ -3759,6 +3773,8 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #162020; }
   .bg--text-inverse-l {
     background-color: #FFFFFF; }
+  .bg--form-ui-l {
+    background-color: #1572BB; }
   .bg--link-l {
     background-color: #1572BB; }
   .bg--link-dark-l {
@@ -3801,6 +3817,8 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #162020; }
   .hover-bg--text-inverse-l:hover {
     background-color: #FFFFFF; }
+  .hover-bg--form-ui-l:hover {
+    background-color: #1572BB; }
   .hover-bg--link-l:hover {
     background-color: #1572BB; }
   .hover-bg--link-dark-l:hover {
@@ -4895,6 +4913,9 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
 .b--text-inverse {
   border-color: #FFFFFF; }
 
+.b--form-ui {
+  border-color: #1572BB; }
+
 .b--link {
   border-color: #1572BB; }
 
@@ -4957,6 +4978,9 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
 
 .hover-b--text-inverse:hover {
   border-color: #FFFFFF; }
+
+.hover-b--form-ui:hover {
+  border-color: #1572BB; }
 
 .hover-b--link:hover {
   border-color: #1572BB; }
@@ -5619,6 +5643,8 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #162020; }
   .b--text-inverse-ns {
     border-color: #FFFFFF; }
+  .b--form-ui-ns {
+    border-color: #1572BB; }
   .b--link-ns {
     border-color: #1572BB; }
   .b--link-dark-ns {
@@ -5661,6 +5687,8 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #162020; }
   .hover-b--text-inverse-ns:hover {
     border-color: #FFFFFF; }
+  .hover-b--form-ui-ns:hover {
+    border-color: #1572BB; }
   .hover-b--link-ns:hover {
     border-color: #1572BB; }
   .hover-b--link-dark-ns:hover {
@@ -6307,6 +6335,8 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #162020; }
   .b--text-inverse-m {
     border-color: #FFFFFF; }
+  .b--form-ui-m {
+    border-color: #1572BB; }
   .b--link-m {
     border-color: #1572BB; }
   .b--link-dark-m {
@@ -6349,6 +6379,8 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #162020; }
   .hover-b--text-inverse-m:hover {
     border-color: #FFFFFF; }
+  .hover-b--form-ui-m:hover {
+    border-color: #1572BB; }
   .hover-b--link-m:hover {
     border-color: #1572BB; }
   .hover-b--link-dark-m:hover {
@@ -6995,6 +7027,8 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #162020; }
   .b--text-inverse-l {
     border-color: #FFFFFF; }
+  .b--form-ui-l {
+    border-color: #1572BB; }
   .b--link-l {
     border-color: #1572BB; }
   .b--link-dark-l {
@@ -7037,6 +7071,8 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #162020; }
   .hover-b--text-inverse-l:hover {
     border-color: #FFFFFF; }
+  .hover-b--form-ui-l:hover {
+    border-color: #1572BB; }
   .hover-b--link-l:hover {
     border-color: #1572BB; }
   .hover-b--link-dark-l:hover {
@@ -8352,6 +8388,9 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
 .c--text-inverse {
   color: #FFFFFF; }
 
+.c--form-ui {
+  color: #1572BB; }
+
 .c--link {
   color: #1572BB; }
 
@@ -8414,6 +8453,9 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
 
 .hover-c--text-inverse:hover {
   color: #FFFFFF; }
+
+.hover-c--form-ui:hover {
+  color: #1572BB; }
 
 .hover-c--link:hover {
   color: #1572BB; }
@@ -9155,6 +9197,8 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #162020; }
   .c--text-inverse-ns {
     color: #FFFFFF; }
+  .c--form-ui-ns {
+    color: #1572BB; }
   .c--link-ns {
     color: #1572BB; }
   .c--link-dark-ns {
@@ -9197,6 +9241,8 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #162020; }
   .hover-c--text-inverse-ns:hover {
     color: #FFFFFF; }
+  .hover-c--form-ui-ns:hover {
+    color: #1572BB; }
   .hover-c--link-ns:hover {
     color: #1572BB; }
   .hover-c--link-dark-ns:hover {
@@ -9938,6 +9984,8 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #162020; }
   .c--text-inverse-m {
     color: #FFFFFF; }
+  .c--form-ui-m {
+    color: #1572BB; }
   .c--link-m {
     color: #1572BB; }
   .c--link-dark-m {
@@ -9980,6 +10028,8 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #162020; }
   .hover-c--text-inverse-m:hover {
     color: #FFFFFF; }
+  .hover-c--form-ui-m:hover {
+    color: #1572BB; }
   .hover-c--link-m:hover {
     color: #1572BB; }
   .hover-c--link-dark-m:hover {
@@ -10721,6 +10771,8 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #162020; }
   .c--text-inverse-l {
     color: #FFFFFF; }
+  .c--form-ui-l {
+    color: #1572BB; }
   .c--link-l {
     color: #1572BB; }
   .c--link-dark-l {
@@ -10763,6 +10815,8 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #162020; }
   .hover-c--text-inverse-l:hover {
     color: #FFFFFF; }
+  .hover-c--form-ui-l:hover {
+    color: #1572BB; }
   .hover-c--link-l:hover {
     color: #1572BB; }
   .hover-c--link-dark-l:hover {

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -1378,7 +1378,7 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
   background-color: #f3f4f4; }
 
 .bg--background-dark {
-  background-color: #002838; }
+  background-color: #002138; }
 
 .bg--background-inverse {
   background-color: #273333; }
@@ -1441,7 +1441,7 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
   background-color: #f3f4f4; }
 
 .hover-bg--background-dark:hover {
-  background-color: #002838; }
+  background-color: #002138; }
 
 .hover-bg--background-inverse:hover {
   background-color: #273333; }
@@ -2204,7 +2204,7 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
   .bg--background-light-ns {
     background-color: #f3f4f4; }
   .bg--background-dark-ns {
-    background-color: #002838; }
+    background-color: #002138; }
   .bg--background-inverse-ns {
     background-color: #273333; }
   .bg--background-hero-ns {
@@ -2246,7 +2246,7 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
   .hover-bg--background-light-ns:hover {
     background-color: #f3f4f4; }
   .hover-bg--background-dark-ns:hover {
-    background-color: #002838; }
+    background-color: #002138; }
   .hover-bg--background-inverse-ns:hover {
     background-color: #273333; }
   .hover-bg--background-hero-ns:hover {
@@ -2988,7 +2988,7 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
   .bg--background-light-m {
     background-color: #f3f4f4; }
   .bg--background-dark-m {
-    background-color: #002838; }
+    background-color: #002138; }
   .bg--background-inverse-m {
     background-color: #273333; }
   .bg--background-hero-m {
@@ -3030,7 +3030,7 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
   .hover-bg--background-light-m:hover {
     background-color: #f3f4f4; }
   .hover-bg--background-dark-m:hover {
-    background-color: #002838; }
+    background-color: #002138; }
   .hover-bg--background-inverse-m:hover {
     background-color: #273333; }
   .hover-bg--background-hero-m:hover {
@@ -3772,7 +3772,7 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
   .bg--background-light-l {
     background-color: #f3f4f4; }
   .bg--background-dark-l {
-    background-color: #002838; }
+    background-color: #002138; }
   .bg--background-inverse-l {
     background-color: #273333; }
   .bg--background-hero-l {
@@ -3814,7 +3814,7 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
   .hover-bg--background-light-l:hover {
     background-color: #f3f4f4; }
   .hover-bg--background-dark-l:hover {
-    background-color: #002838; }
+    background-color: #002138; }
   .hover-bg--background-inverse-l:hover {
     background-color: #273333; }
   .hover-bg--background-hero-l:hover {
@@ -4914,7 +4914,7 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
   border-color: #f3f4f4; }
 
 .b--background-dark {
-  border-color: #002838; }
+  border-color: #002138; }
 
 .b--background-inverse {
   border-color: #273333; }
@@ -4977,7 +4977,7 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
   border-color: #f3f4f4; }
 
 .hover-b--background-dark:hover {
-  border-color: #002838; }
+  border-color: #002138; }
 
 .hover-b--background-inverse:hover {
   border-color: #273333; }
@@ -5632,7 +5632,7 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
   .b--background-light-ns {
     border-color: #f3f4f4; }
   .b--background-dark-ns {
-    border-color: #002838; }
+    border-color: #002138; }
   .b--background-inverse-ns {
     border-color: #273333; }
   .b--background-hero-ns {
@@ -5674,7 +5674,7 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
   .hover-b--background-light-ns:hover {
     border-color: #f3f4f4; }
   .hover-b--background-dark-ns:hover {
-    border-color: #002838; }
+    border-color: #002138; }
   .hover-b--background-inverse-ns:hover {
     border-color: #273333; }
   .hover-b--background-hero-ns:hover {
@@ -6320,7 +6320,7 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
   .b--background-light-m {
     border-color: #f3f4f4; }
   .b--background-dark-m {
-    border-color: #002838; }
+    border-color: #002138; }
   .b--background-inverse-m {
     border-color: #273333; }
   .b--background-hero-m {
@@ -6362,7 +6362,7 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
   .hover-b--background-light-m:hover {
     border-color: #f3f4f4; }
   .hover-b--background-dark-m:hover {
-    border-color: #002838; }
+    border-color: #002138; }
   .hover-b--background-inverse-m:hover {
     border-color: #273333; }
   .hover-b--background-hero-m:hover {
@@ -7008,7 +7008,7 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
   .b--background-light-l {
     border-color: #f3f4f4; }
   .b--background-dark-l {
-    border-color: #002838; }
+    border-color: #002138; }
   .b--background-inverse-l {
     border-color: #273333; }
   .b--background-hero-l {
@@ -7050,7 +7050,7 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
   .hover-b--background-light-l:hover {
     border-color: #f3f4f4; }
   .hover-b--background-dark-l:hover {
-    border-color: #002838; }
+    border-color: #002138; }
   .hover-b--background-inverse-l:hover {
     border-color: #273333; }
   .hover-b--background-hero-l:hover {
@@ -8371,7 +8371,7 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
   color: #f3f4f4; }
 
 .c--background-dark {
-  color: #002838; }
+  color: #002138; }
 
 .c--background-inverse {
   color: #273333; }
@@ -8434,7 +8434,7 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
   color: #f3f4f4; }
 
 .hover-c--background-dark:hover {
-  color: #002838; }
+  color: #002138; }
 
 .hover-c--background-inverse:hover {
   color: #273333; }
@@ -9168,7 +9168,7 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
   .c--background-light-ns {
     color: #f3f4f4; }
   .c--background-dark-ns {
-    color: #002838; }
+    color: #002138; }
   .c--background-inverse-ns {
     color: #273333; }
   .c--background-hero-ns {
@@ -9210,7 +9210,7 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
   .hover-c--background-light-ns:hover {
     color: #f3f4f4; }
   .hover-c--background-dark-ns:hover {
-    color: #002838; }
+    color: #002138; }
   .hover-c--background-inverse-ns:hover {
     color: #273333; }
   .hover-c--background-hero-ns:hover {
@@ -9951,7 +9951,7 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
   .c--background-light-m {
     color: #f3f4f4; }
   .c--background-dark-m {
-    color: #002838; }
+    color: #002138; }
   .c--background-inverse-m {
     color: #273333; }
   .c--background-hero-m {
@@ -9993,7 +9993,7 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
   .hover-c--background-light-m:hover {
     color: #f3f4f4; }
   .hover-c--background-dark-m:hover {
-    color: #002838; }
+    color: #002138; }
   .hover-c--background-inverse-m:hover {
     color: #273333; }
   .hover-c--background-hero-m:hover {
@@ -10734,7 +10734,7 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
   .c--background-light-l {
     color: #f3f4f4; }
   .c--background-dark-l {
-    color: #002838; }
+    color: #002138; }
   .c--background-inverse-l {
     color: #273333; }
   .c--background-hero-l {
@@ -10776,7 +10776,7 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
   .hover-c--background-light-l:hover {
     color: #f3f4f4; }
   .hover-c--background-dark-l:hover {
-    color: #002838; }
+    color: #002138; }
   .hover-c--background-inverse-l:hover {
     color: #273333; }
   .hover-c--background-hero-l:hover {

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -1350,9 +1350,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
 .bg--text {
   background-color: #162020; }
 
-.bg--text-light {
-  background-color: #929a9b; }
-
 .bg--text-dark {
   background-color: #162020; }
 
@@ -1415,9 +1412,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
 
 .hover-bg--text:hover {
   background-color: #162020; }
-
-.hover-bg--text-light:hover {
-  background-color: #929a9b; }
 
 .hover-bg--text-dark:hover {
   background-color: #162020; }
@@ -2191,8 +2185,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #008b46; }
   .bg--text-ns {
     background-color: #162020; }
-  .bg--text-light-ns {
-    background-color: #929a9b; }
   .bg--text-dark-ns {
     background-color: #162020; }
   .bg--text-inverse-ns {
@@ -2235,8 +2227,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #008b46; }
   .hover-bg--text-ns:hover {
     background-color: #162020; }
-  .hover-bg--text-light-ns:hover {
-    background-color: #929a9b; }
   .hover-bg--text-dark-ns:hover {
     background-color: #162020; }
   .hover-bg--text-inverse-ns:hover {
@@ -2979,8 +2969,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #008b46; }
   .bg--text-m {
     background-color: #162020; }
-  .bg--text-light-m {
-    background-color: #929a9b; }
   .bg--text-dark-m {
     background-color: #162020; }
   .bg--text-inverse-m {
@@ -3023,8 +3011,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #008b46; }
   .hover-bg--text-m:hover {
     background-color: #162020; }
-  .hover-bg--text-light-m:hover {
-    background-color: #929a9b; }
   .hover-bg--text-dark-m:hover {
     background-color: #162020; }
   .hover-bg--text-inverse-m:hover {
@@ -3767,8 +3753,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #008b46; }
   .bg--text-l {
     background-color: #162020; }
-  .bg--text-light-l {
-    background-color: #929a9b; }
   .bg--text-dark-l {
     background-color: #162020; }
   .bg--text-inverse-l {
@@ -3811,8 +3795,6 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #008b46; }
   .hover-bg--text-l:hover {
     background-color: #162020; }
-  .hover-bg--text-light-l:hover {
-    background-color: #929a9b; }
   .hover-bg--text-dark-l:hover {
     background-color: #162020; }
   .hover-bg--text-inverse-l:hover {
@@ -4904,9 +4886,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
 .b--text {
   border-color: #162020; }
 
-.b--text-light {
-  border-color: #929a9b; }
-
 .b--text-dark {
   border-color: #162020; }
 
@@ -4969,9 +4948,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
 
 .hover-b--text:hover {
   border-color: #162020; }
-
-.hover-b--text-light:hover {
-  border-color: #929a9b; }
 
 .hover-b--text-dark:hover {
   border-color: #162020; }
@@ -5637,8 +5613,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #008b46; }
   .b--text-ns {
     border-color: #162020; }
-  .b--text-light-ns {
-    border-color: #929a9b; }
   .b--text-dark-ns {
     border-color: #162020; }
   .b--text-inverse-ns {
@@ -5681,8 +5655,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #008b46; }
   .hover-b--text-ns:hover {
     border-color: #162020; }
-  .hover-b--text-light-ns:hover {
-    border-color: #929a9b; }
   .hover-b--text-dark-ns:hover {
     border-color: #162020; }
   .hover-b--text-inverse-ns:hover {
@@ -6329,8 +6301,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #008b46; }
   .b--text-m {
     border-color: #162020; }
-  .b--text-light-m {
-    border-color: #929a9b; }
   .b--text-dark-m {
     border-color: #162020; }
   .b--text-inverse-m {
@@ -6373,8 +6343,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #008b46; }
   .hover-b--text-m:hover {
     border-color: #162020; }
-  .hover-b--text-light-m:hover {
-    border-color: #929a9b; }
   .hover-b--text-dark-m:hover {
     border-color: #162020; }
   .hover-b--text-inverse-m:hover {
@@ -7021,8 +6989,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #008b46; }
   .b--text-l {
     border-color: #162020; }
-  .b--text-light-l {
-    border-color: #929a9b; }
   .b--text-dark-l {
     border-color: #162020; }
   .b--text-inverse-l {
@@ -7065,8 +7031,6 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #008b46; }
   .hover-b--text-l:hover {
     border-color: #162020; }
-  .hover-b--text-light-l:hover {
-    border-color: #929a9b; }
   .hover-b--text-dark-l:hover {
     border-color: #162020; }
   .hover-b--text-inverse-l:hover {
@@ -8379,9 +8343,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
 .c--text {
   color: #162020; }
 
-.c--text-light {
-  color: #929a9b; }
-
 .c--text-dark {
   color: #162020; }
 
@@ -8444,9 +8405,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
 
 .hover-c--text:hover {
   color: #162020; }
-
-.hover-c--text-light:hover {
-  color: #929a9b; }
 
 .hover-c--text-dark:hover {
   color: #162020; }
@@ -9191,8 +9149,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #008b46; }
   .c--text-ns {
     color: #162020; }
-  .c--text-light-ns {
-    color: #929a9b; }
   .c--text-dark-ns {
     color: #162020; }
   .c--text-inverse-ns {
@@ -9235,8 +9191,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #008b46; }
   .hover-c--text-ns:hover {
     color: #162020; }
-  .hover-c--text-light-ns:hover {
-    color: #929a9b; }
   .hover-c--text-dark-ns:hover {
     color: #162020; }
   .hover-c--text-inverse-ns:hover {
@@ -9978,8 +9932,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #008b46; }
   .c--text-m {
     color: #162020; }
-  .c--text-light-m {
-    color: #929a9b; }
   .c--text-dark-m {
     color: #162020; }
   .c--text-inverse-m {
@@ -10022,8 +9974,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #008b46; }
   .hover-c--text-m:hover {
     color: #162020; }
-  .hover-c--text-light-m:hover {
-    color: #929a9b; }
   .hover-c--text-dark-m:hover {
     color: #162020; }
   .hover-c--text-inverse-m:hover {
@@ -10765,8 +10715,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #008b46; }
   .c--text-l {
     color: #162020; }
-  .c--text-light-l {
-    color: #929a9b; }
   .c--text-dark-l {
     color: #162020; }
   .c--text-inverse-l {
@@ -10809,8 +10757,6 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #008b46; }
   .hover-c--text-l:hover {
     color: #162020; }
-  .hover-c--text-light-l:hover {
-    color: #929a9b; }
   .hover-c--text-dark-l:hover {
     color: #162020; }
   .hover-c--text-inverse-l:hover {

--- a/packets/seedlings/src/_text-decoration.scss
+++ b/packets/seedlings/src/_text-decoration.scss
@@ -24,7 +24,7 @@ Example: <div class="db f500 {{modifier}}">The quick brown fox...</div><p>{{labe
     width: $length;
     height: Space(300);
     margin-bottom: Space(400);
-    background-color: theme-color(main, dark);
+    background-color: theme-color(primary, dark);
     content: "";
   }
 }

--- a/packets/seedlings/src/axioms/Colors.scss
+++ b/packets/seedlings/src/axioms/Colors.scss
@@ -325,8 +325,7 @@ $colors-networks: (
 $theme-colors: (
         main: (
                 default: get-color(green, 700),
-                dark: get-color(green, 800),
-                darkest: get-color(green, 900)
+                dark: get-color(green, 800)
         ),
         text: (
                 default: get-color(neutral, 1000),
@@ -345,9 +344,6 @@ $theme-colors: (
                 light: get-color(neutral, 100),
                 dark: get-color(aqua, 1100),
                 inverse: get-color(neutral, 900)
-        ),
-        background-card: (
-                default: get-color(neutral, 0)
         ),
         background-hero: (
                 default: get-color(neutral, 900),

--- a/packets/seedlings/src/axioms/Colors.scss
+++ b/packets/seedlings/src/axioms/Colors.scss
@@ -393,7 +393,7 @@ $theme-colors: (
 /// @param {string} $variant [default] - The color variant to get.
 ///
 /// @example scss - Usage in an Axiom or Pattern
-/// $blast-background: theme-color(main);
+/// $blast-background: theme-color(primary);
 /// $blast-color: theme-color(text, inverse);
 @function theme-color($type, $variant: default) {
   @return map-get(map-get($theme-colors, $type), $variant);

--- a/packets/seedlings/src/axioms/Colors.scss
+++ b/packets/seedlings/src/axioms/Colors.scss
@@ -342,7 +342,7 @@ $theme-colors: (
         background: (
                 default: get-color(neutral, 0),
                 light: get-color(neutral, 100),
-                dark: get-color(aqua, 1100),
+                dark: get-color(blue, 1100),
                 inverse: get-color(neutral, 900)
         ),
         background-hero: (

--- a/packets/seedlings/src/axioms/Colors.scss
+++ b/packets/seedlings/src/axioms/Colors.scss
@@ -321,11 +321,12 @@ $colors-networks: (
 }
 
 /// The default theme color palette. These colors are used by themeable patterns to render a new look and feel.
+/// Them 'main' and 'secondary' themes are being deprecated → use 'primary' theme instead
 /// @type map
 $theme-colors: (
         main: (
-                default: get-color(green, 700),
-                dark: get-color(green, 800)
+                default: get-color(green, 700), /* DEPRECATED - use 'primary' theme-color */
+                dark: get-color(green, 800) /* DEPRECATED - use 'primary-dark' theme-color */
         ),
         text: (
                 default: get-color(neutral, 1000),
@@ -358,8 +359,8 @@ $theme-colors: (
                 dark: get-color(green, 800)
         ),
         secondary: (
-                default: get-color(green, 700),
-                dark: get-color(green, 800)
+                default: get-color(green, 700), /* DEPRECATED - use 'primary' theme-color */
+                dark: get-color(green, 800) /* DEPRECATED - use 'primary-dark' theme-color */
         )
 ) !default;
 

--- a/packets/seedlings/src/axioms/Colors.scss
+++ b/packets/seedlings/src/axioms/Colors.scss
@@ -330,7 +330,6 @@ $theme-colors: (
         ),
         text: (
                 default: get-color(neutral, 1000),
-                light: get-color(neutral, 500),
                 dark: get-color(neutral, 1000),
                 inverse: get-color(neutral, 0)
         ),

--- a/packets/seedlings/src/axioms/Colors.scss
+++ b/packets/seedlings/src/axioms/Colors.scss
@@ -333,6 +333,9 @@ $theme-colors: (
                 dark: get-color(neutral, 1000),
                 inverse: get-color(neutral, 0)
         ),
+        form-ui: (
+                default: $accessible-blue
+        ),
         link: (
                 default: $accessible-blue,
                 dark: get-color(blue, 1000),


### PR DESCRIPTION
<!--- Please add Jira story (if applicable) at start of your PR title (ex: "SEEDS-123 ...") -->

## Description: 
Deprecate duplicated and unused theme-colors from Seedlings. Preps codebases consuming Seedlings for new semantic color tokens & future updates for button colors.

<!--- Create a bullet list of the changes you've made -->

- Removed `main-darkest`
- Removed `text-light`
- Removed `background-card`
- Added `form-ui` (new link color)
- Added deprecation notice to `main` and `secondary` themes
- Pointed any references of `theme-color(main)` to `theme-color(primary)`

## GitHub pages build link:



## Jira:

- [MBC-8079](https://sprout.atlassian.net/browse/MBC-8079)
