### PR TITLE
Use blue.800 for links and forms [MBC 8395]

### DIFF
--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -1357,10 +1357,13 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
   background-color: #FFFFFF; }
 
 .bg--form-ui {
-  background-color: #1572BB; }
+  background-color: #116daa; }
+
+.bg--form-ui-interaction {
+  background-color: #0c5689; }
 
 .bg--link {
-  background-color: #1572BB; }
+  background-color: #116daa; }
 
 .bg--link-dark {
   background-color: #0a3960; }
@@ -1420,10 +1423,13 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
   background-color: #FFFFFF; }
 
 .hover-bg--form-ui:hover {
-  background-color: #1572BB; }
+  background-color: #116daa; }
+
+.hover-bg--form-ui-interaction:hover {
+  background-color: #0c5689; }
 
 .hover-bg--link:hover {
-  background-color: #1572BB; }
+  background-color: #116daa; }
 
 .hover-bg--link-dark:hover {
   background-color: #0a3960; }
@@ -2190,9 +2196,11 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
   .bg--text-inverse-ns {
     background-color: #FFFFFF; }
   .bg--form-ui-ns {
-    background-color: #1572BB; }
+    background-color: #116daa; }
+  .bg--form-ui-interaction-ns {
+    background-color: #0c5689; }
   .bg--link-ns {
-    background-color: #1572BB; }
+    background-color: #116daa; }
   .bg--link-dark-ns {
     background-color: #0a3960; }
   .bg--link-white-ns {
@@ -2232,9 +2240,11 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
   .hover-bg--text-inverse-ns:hover {
     background-color: #FFFFFF; }
   .hover-bg--form-ui-ns:hover {
-    background-color: #1572BB; }
+    background-color: #116daa; }
+  .hover-bg--form-ui-interaction-ns:hover {
+    background-color: #0c5689; }
   .hover-bg--link-ns:hover {
-    background-color: #1572BB; }
+    background-color: #116daa; }
   .hover-bg--link-dark-ns:hover {
     background-color: #0a3960; }
   .hover-bg--link-white-ns:hover {
@@ -2974,9 +2984,11 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
   .bg--text-inverse-m {
     background-color: #FFFFFF; }
   .bg--form-ui-m {
-    background-color: #1572BB; }
+    background-color: #116daa; }
+  .bg--form-ui-interaction-m {
+    background-color: #0c5689; }
   .bg--link-m {
-    background-color: #1572BB; }
+    background-color: #116daa; }
   .bg--link-dark-m {
     background-color: #0a3960; }
   .bg--link-white-m {
@@ -3016,9 +3028,11 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
   .hover-bg--text-inverse-m:hover {
     background-color: #FFFFFF; }
   .hover-bg--form-ui-m:hover {
-    background-color: #1572BB; }
+    background-color: #116daa; }
+  .hover-bg--form-ui-interaction-m:hover {
+    background-color: #0c5689; }
   .hover-bg--link-m:hover {
-    background-color: #1572BB; }
+    background-color: #116daa; }
   .hover-bg--link-dark-m:hover {
     background-color: #0a3960; }
   .hover-bg--link-white-m:hover {
@@ -3758,9 +3772,11 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
   .bg--text-inverse-l {
     background-color: #FFFFFF; }
   .bg--form-ui-l {
-    background-color: #1572BB; }
+    background-color: #116daa; }
+  .bg--form-ui-interaction-l {
+    background-color: #0c5689; }
   .bg--link-l {
-    background-color: #1572BB; }
+    background-color: #116daa; }
   .bg--link-dark-l {
     background-color: #0a3960; }
   .bg--link-white-l {
@@ -3800,9 +3816,11 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
   .hover-bg--text-inverse-l:hover {
     background-color: #FFFFFF; }
   .hover-bg--form-ui-l:hover {
-    background-color: #1572BB; }
+    background-color: #116daa; }
+  .hover-bg--form-ui-interaction-l:hover {
+    background-color: #0c5689; }
   .hover-bg--link-l:hover {
-    background-color: #1572BB; }
+    background-color: #116daa; }
   .hover-bg--link-dark-l:hover {
     background-color: #0a3960; }
   .hover-bg--link-white-l:hover {
@@ -4893,10 +4911,13 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
   border-color: #FFFFFF; }
 
 .b--form-ui {
-  border-color: #1572BB; }
+  border-color: #116daa; }
+
+.b--form-ui-interaction {
+  border-color: #0c5689; }
 
 .b--link {
-  border-color: #1572BB; }
+  border-color: #116daa; }
 
 .b--link-dark {
   border-color: #0a3960; }
@@ -4956,10 +4977,13 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
   border-color: #FFFFFF; }
 
 .hover-b--form-ui:hover {
-  border-color: #1572BB; }
+  border-color: #116daa; }
+
+.hover-b--form-ui-interaction:hover {
+  border-color: #0c5689; }
 
 .hover-b--link:hover {
-  border-color: #1572BB; }
+  border-color: #116daa; }
 
 .hover-b--link-dark:hover {
   border-color: #0a3960; }
@@ -5618,9 +5642,11 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
   .b--text-inverse-ns {
     border-color: #FFFFFF; }
   .b--form-ui-ns {
-    border-color: #1572BB; }
+    border-color: #116daa; }
+  .b--form-ui-interaction-ns {
+    border-color: #0c5689; }
   .b--link-ns {
-    border-color: #1572BB; }
+    border-color: #116daa; }
   .b--link-dark-ns {
     border-color: #0a3960; }
   .b--link-white-ns {
@@ -5660,9 +5686,11 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
   .hover-b--text-inverse-ns:hover {
     border-color: #FFFFFF; }
   .hover-b--form-ui-ns:hover {
-    border-color: #1572BB; }
+    border-color: #116daa; }
+  .hover-b--form-ui-interaction-ns:hover {
+    border-color: #0c5689; }
   .hover-b--link-ns:hover {
-    border-color: #1572BB; }
+    border-color: #116daa; }
   .hover-b--link-dark-ns:hover {
     border-color: #0a3960; }
   .hover-b--link-white-ns:hover {
@@ -6306,9 +6334,11 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
   .b--text-inverse-m {
     border-color: #FFFFFF; }
   .b--form-ui-m {
-    border-color: #1572BB; }
+    border-color: #116daa; }
+  .b--form-ui-interaction-m {
+    border-color: #0c5689; }
   .b--link-m {
-    border-color: #1572BB; }
+    border-color: #116daa; }
   .b--link-dark-m {
     border-color: #0a3960; }
   .b--link-white-m {
@@ -6348,9 +6378,11 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
   .hover-b--text-inverse-m:hover {
     border-color: #FFFFFF; }
   .hover-b--form-ui-m:hover {
-    border-color: #1572BB; }
+    border-color: #116daa; }
+  .hover-b--form-ui-interaction-m:hover {
+    border-color: #0c5689; }
   .hover-b--link-m:hover {
-    border-color: #1572BB; }
+    border-color: #116daa; }
   .hover-b--link-dark-m:hover {
     border-color: #0a3960; }
   .hover-b--link-white-m:hover {
@@ -6994,9 +7026,11 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
   .b--text-inverse-l {
     border-color: #FFFFFF; }
   .b--form-ui-l {
-    border-color: #1572BB; }
+    border-color: #116daa; }
+  .b--form-ui-interaction-l {
+    border-color: #0c5689; }
   .b--link-l {
-    border-color: #1572BB; }
+    border-color: #116daa; }
   .b--link-dark-l {
     border-color: #0a3960; }
   .b--link-white-l {
@@ -7036,9 +7070,11 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
   .hover-b--text-inverse-l:hover {
     border-color: #FFFFFF; }
   .hover-b--form-ui-l:hover {
-    border-color: #1572BB; }
+    border-color: #116daa; }
+  .hover-b--form-ui-interaction-l:hover {
+    border-color: #0c5689; }
   .hover-b--link-l:hover {
-    border-color: #1572BB; }
+    border-color: #116daa; }
   .hover-b--link-dark-l:hover {
     border-color: #0a3960; }
   .hover-b--link-white-l:hover {
@@ -8350,10 +8386,13 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
   color: #FFFFFF; }
 
 .c--form-ui {
-  color: #1572BB; }
+  color: #116daa; }
+
+.c--form-ui-interaction {
+  color: #0c5689; }
 
 .c--link {
-  color: #1572BB; }
+  color: #116daa; }
 
 .c--link-dark {
   color: #0a3960; }
@@ -8413,10 +8452,13 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
   color: #FFFFFF; }
 
 .hover-c--form-ui:hover {
-  color: #1572BB; }
+  color: #116daa; }
+
+.hover-c--form-ui-interaction:hover {
+  color: #0c5689; }
 
 .hover-c--link:hover {
-  color: #1572BB; }
+  color: #116daa; }
 
 .hover-c--link-dark:hover {
   color: #0a3960; }
@@ -9154,9 +9196,11 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
   .c--text-inverse-ns {
     color: #FFFFFF; }
   .c--form-ui-ns {
-    color: #1572BB; }
+    color: #116daa; }
+  .c--form-ui-interaction-ns {
+    color: #0c5689; }
   .c--link-ns {
-    color: #1572BB; }
+    color: #116daa; }
   .c--link-dark-ns {
     color: #0a3960; }
   .c--link-white-ns {
@@ -9196,9 +9240,11 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
   .hover-c--text-inverse-ns:hover {
     color: #FFFFFF; }
   .hover-c--form-ui-ns:hover {
-    color: #1572BB; }
+    color: #116daa; }
+  .hover-c--form-ui-interaction-ns:hover {
+    color: #0c5689; }
   .hover-c--link-ns:hover {
-    color: #1572BB; }
+    color: #116daa; }
   .hover-c--link-dark-ns:hover {
     color: #0a3960; }
   .hover-c--link-white-ns:hover {
@@ -9937,9 +9983,11 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
   .c--text-inverse-m {
     color: #FFFFFF; }
   .c--form-ui-m {
-    color: #1572BB; }
+    color: #116daa; }
+  .c--form-ui-interaction-m {
+    color: #0c5689; }
   .c--link-m {
-    color: #1572BB; }
+    color: #116daa; }
   .c--link-dark-m {
     color: #0a3960; }
   .c--link-white-m {
@@ -9979,9 +10027,11 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
   .hover-c--text-inverse-m:hover {
     color: #FFFFFF; }
   .hover-c--form-ui-m:hover {
-    color: #1572BB; }
+    color: #116daa; }
+  .hover-c--form-ui-interaction-m:hover {
+    color: #0c5689; }
   .hover-c--link-m:hover {
-    color: #1572BB; }
+    color: #116daa; }
   .hover-c--link-dark-m:hover {
     color: #0a3960; }
   .hover-c--link-white-m:hover {
@@ -10720,9 +10770,11 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
   .c--text-inverse-l {
     color: #FFFFFF; }
   .c--form-ui-l {
-    color: #1572BB; }
+    color: #116daa; }
+  .c--form-ui-interaction-l {
+    color: #0c5689; }
   .c--link-l {
-    color: #1572BB; }
+    color: #116daa; }
   .c--link-dark-l {
     color: #0a3960; }
   .c--link-white-l {
@@ -10762,9 +10814,11 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
   .hover-c--text-inverse-l:hover {
     color: #FFFFFF; }
   .hover-c--form-ui-l:hover {
-    color: #1572BB; }
+    color: #116daa; }
+  .hover-c--form-ui-interaction-l:hover {
+    color: #0c5689; }
   .hover-c--link-l:hover {
-    color: #1572BB; }
+    color: #116daa; }
   .hover-c--link-dark-l:hover {
     color: #0a3960; }
   .hover-c--link-white-l:hover {

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -1365,6 +1365,9 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
 .bg--link {
   background-color: #116daa; }
 
+.bg--link-interaction {
+  background-color: #0c5689; }
+
 .bg--link-dark {
   background-color: #0a3960; }
 
@@ -1430,6 +1433,9 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
 
 .hover-bg--link:hover {
   background-color: #116daa; }
+
+.hover-bg--link-interaction:hover {
+  background-color: #0c5689; }
 
 .hover-bg--link-dark:hover {
   background-color: #0a3960; }
@@ -2201,6 +2207,8 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #0c5689; }
   .bg--link-ns {
     background-color: #116daa; }
+  .bg--link-interaction-ns {
+    background-color: #0c5689; }
   .bg--link-dark-ns {
     background-color: #0a3960; }
   .bg--link-white-ns {
@@ -2245,6 +2253,8 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #0c5689; }
   .hover-bg--link-ns:hover {
     background-color: #116daa; }
+  .hover-bg--link-interaction-ns:hover {
+    background-color: #0c5689; }
   .hover-bg--link-dark-ns:hover {
     background-color: #0a3960; }
   .hover-bg--link-white-ns:hover {
@@ -2989,6 +2999,8 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #0c5689; }
   .bg--link-m {
     background-color: #116daa; }
+  .bg--link-interaction-m {
+    background-color: #0c5689; }
   .bg--link-dark-m {
     background-color: #0a3960; }
   .bg--link-white-m {
@@ -3033,6 +3045,8 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #0c5689; }
   .hover-bg--link-m:hover {
     background-color: #116daa; }
+  .hover-bg--link-interaction-m:hover {
+    background-color: #0c5689; }
   .hover-bg--link-dark-m:hover {
     background-color: #0a3960; }
   .hover-bg--link-white-m:hover {
@@ -3777,6 +3791,8 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #0c5689; }
   .bg--link-l {
     background-color: #116daa; }
+  .bg--link-interaction-l {
+    background-color: #0c5689; }
   .bg--link-dark-l {
     background-color: #0a3960; }
   .bg--link-white-l {
@@ -3821,6 +3837,8 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: #0c5689; }
   .hover-bg--link-l:hover {
     background-color: #116daa; }
+  .hover-bg--link-interaction-l:hover {
+    background-color: #0c5689; }
   .hover-bg--link-dark-l:hover {
     background-color: #0a3960; }
   .hover-bg--link-white-l:hover {
@@ -4919,6 +4937,9 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
 .b--link {
   border-color: #116daa; }
 
+.b--link-interaction {
+  border-color: #0c5689; }
+
 .b--link-dark {
   border-color: #0a3960; }
 
@@ -4984,6 +5005,9 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
 
 .hover-b--link:hover {
   border-color: #116daa; }
+
+.hover-b--link-interaction:hover {
+  border-color: #0c5689; }
 
 .hover-b--link-dark:hover {
   border-color: #0a3960; }
@@ -5647,6 +5671,8 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #0c5689; }
   .b--link-ns {
     border-color: #116daa; }
+  .b--link-interaction-ns {
+    border-color: #0c5689; }
   .b--link-dark-ns {
     border-color: #0a3960; }
   .b--link-white-ns {
@@ -5691,6 +5717,8 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #0c5689; }
   .hover-b--link-ns:hover {
     border-color: #116daa; }
+  .hover-b--link-interaction-ns:hover {
+    border-color: #0c5689; }
   .hover-b--link-dark-ns:hover {
     border-color: #0a3960; }
   .hover-b--link-white-ns:hover {
@@ -6339,6 +6367,8 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #0c5689; }
   .b--link-m {
     border-color: #116daa; }
+  .b--link-interaction-m {
+    border-color: #0c5689; }
   .b--link-dark-m {
     border-color: #0a3960; }
   .b--link-white-m {
@@ -6383,6 +6413,8 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #0c5689; }
   .hover-b--link-m:hover {
     border-color: #116daa; }
+  .hover-b--link-interaction-m:hover {
+    border-color: #0c5689; }
   .hover-b--link-dark-m:hover {
     border-color: #0a3960; }
   .hover-b--link-white-m:hover {
@@ -7031,6 +7063,8 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #0c5689; }
   .b--link-l {
     border-color: #116daa; }
+  .b--link-interaction-l {
+    border-color: #0c5689; }
   .b--link-dark-l {
     border-color: #0a3960; }
   .b--link-white-l {
@@ -7075,6 +7109,8 @@ Example: <div class="db bt bw600 {{modifier}}"></div><p>{{label}}</p>
     border-color: #0c5689; }
   .hover-b--link-l:hover {
     border-color: #116daa; }
+  .hover-b--link-interaction-l:hover {
+    border-color: #0c5689; }
   .hover-b--link-dark-l:hover {
     border-color: #0a3960; }
   .hover-b--link-white-l:hover {
@@ -8394,6 +8430,9 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
 .c--link {
   color: #116daa; }
 
+.c--link-interaction {
+  color: #0c5689; }
+
 .c--link-dark {
   color: #0a3960; }
 
@@ -8459,6 +8498,9 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
 
 .hover-c--link:hover {
   color: #116daa; }
+
+.hover-c--link-interaction:hover {
+  color: #0c5689; }
 
 .hover-c--link-dark:hover {
   color: #0a3960; }
@@ -9201,6 +9243,8 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #0c5689; }
   .c--link-ns {
     color: #116daa; }
+  .c--link-interaction-ns {
+    color: #0c5689; }
   .c--link-dark-ns {
     color: #0a3960; }
   .c--link-white-ns {
@@ -9245,6 +9289,8 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #0c5689; }
   .hover-c--link-ns:hover {
     color: #116daa; }
+  .hover-c--link-interaction-ns:hover {
+    color: #0c5689; }
   .hover-c--link-dark-ns:hover {
     color: #0a3960; }
   .hover-c--link-white-ns:hover {
@@ -9988,6 +10034,8 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #0c5689; }
   .c--link-m {
     color: #116daa; }
+  .c--link-interaction-m {
+    color: #0c5689; }
   .c--link-dark-m {
     color: #0a3960; }
   .c--link-white-m {
@@ -10032,6 +10080,8 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #0c5689; }
   .hover-c--link-m:hover {
     color: #116daa; }
+  .hover-c--link-interaction-m:hover {
+    color: #0c5689; }
   .hover-c--link-dark-m:hover {
     color: #0a3960; }
   .hover-c--link-white-m:hover {
@@ -10775,6 +10825,8 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #0c5689; }
   .c--link-l {
     color: #116daa; }
+  .c--link-interaction-l {
+    color: #0c5689; }
   .c--link-dark-l {
     color: #0a3960; }
   .c--link-white-l {
@@ -10819,6 +10871,8 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     color: #0c5689; }
   .hover-c--link-l:hover {
     color: #116daa; }
+  .hover-c--link-interaction-l:hover {
+    color: #0c5689; }
   .hover-c--link-dark-l:hover {
     color: #0a3960; }
   .hover-c--link-white-l:hover {

--- a/packets/seedlings/src/axioms/Colors.scss
+++ b/packets/seedlings/src/axioms/Colors.scss
@@ -204,6 +204,7 @@ $grays-without-gray: $grays;
 // so new value allows this link to work on all our standard background colors in Marketing.
 // While Product is working on colors & color-contrast, we aren't adding this as a Seeds token at this time.
 $accessible-blue: #1572BB;
+// TODO remove this variable
 
 /// Brand colors from social networks. Use the `get-network-color()` function to retrieve them.
 /// @type map
@@ -334,10 +335,11 @@ $theme-colors: (
                 inverse: get-color(neutral, 0)
         ),
         form-ui: (
-                default: $accessible-blue
+                default: get-color(blue, 800),
+                interaction: get-color(blue, 900)
         ),
         link: (
-                default: $accessible-blue,
+                default: get-color(blue, 800),
                 dark: get-color(blue, 1000),
                 white: get-color(neutral, 0),
                 inverse: get-color(neutral, 0)

--- a/packets/seedlings/src/axioms/Colors.scss
+++ b/packets/seedlings/src/axioms/Colors.scss
@@ -200,12 +200,6 @@ $grays: (
 ) !default;
 $grays-without-gray: $grays;
 
-// Blue.700 barely fails contrast requirements against our Light Page Backgrounds (Neutral.100) 
-// so new value allows this link to work on all our standard background colors in Marketing.
-// While Product is working on colors & color-contrast, we aren't adding this as a Seeds token at this time.
-$accessible-blue: #1572BB;
-// TODO remove this variable
-
 /// Brand colors from social networks. Use the `get-network-color()` function to retrieve them.
 /// @type map
 $colors-networks: (
@@ -340,9 +334,10 @@ $theme-colors: (
         ),
         link: (
                 default: get-color(blue, 800),
+                interaction: get-color(blue, 900),
                 dark: get-color(blue, 1000),
                 white: get-color(neutral, 0),
-                inverse: get-color(neutral, 0)
+                inverse: get-color(neutral, 0) /* DEPRECATED - use 'link-white' theme-color */
         ),
         background: (
                 default: get-color(neutral, 0),


### PR DESCRIPTION
<!--- Please add Jira story (if applicable) at start of your PR title (ex: "SEEDS-123 ...") -->

## Description:
We're aligning with Seeds Colors to drop the "new blue 700", a.k.a. "link blue", and instead use the existing Seeds value of Blue.800, which is now what the Product uses for links.
<!--- Create a bullet list of the changes you've made -->

- remove `$accessible-blue` non-seeds color
- update theme color `--link` to `Blue.800`
- include a semantic token for link hover

## Jira:

- [MBC-8395](https://sprout.atlassian.net/browse/MBC-8395)

