### PR TITLE
[MBC-8148] adding a color for free tools landing page

### DIFF
--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -316,8 +316,8 @@ Modifiers:
     --light-translucent: light transparent
     --teal-100-o-80p: Teal 100 (80% opacity)
     --teal-600-o-40p: Teal 600 (40% opacity)
-    --teal-700-o-20p: Teal 700 (20% opacity)
     --teal-700-o-30p: Teal 700 (30% opacity)
+    --teal-700-o-20p: Teal 700 (20% opacity)
     --teal-1000-o-40p: Teal 1000 (40% opacity)
     --blue-700-o-20p: Blue 700 (20% opacity)
     --neutral-0-o-10p: Neutral 0 (10% opacity)

--- a/packets/seedlings/dist/seedlings-marketing.css
+++ b/packets/seedlings/dist/seedlings-marketing.css
@@ -316,6 +316,7 @@ Modifiers:
     --light-translucent: light transparent
     --teal-100-o-80p: Teal 100 (80% opacity)
     --teal-600-o-40p: Teal 600 (40% opacity)
+    --teal-700-o-20p: Teal 700 (20% opacity)
     --teal-700-o-30p: Teal 700 (30% opacity)
     --teal-1000-o-40p: Teal 1000 (40% opacity)
     --blue-700-o-20p: Blue 700 (20% opacity)
@@ -1497,6 +1498,9 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
 .bg--teal-600-o-40p {
   background-color: rgba(0, 169, 156, 0.4); }
 
+.bg--teal-700-o-20p {
+  background-color: rgba(11, 150, 143, 0.2); }
+
 .bg--teal-700-o-30p {
   background-color: rgba(11, 150, 143, 0.3); }
 
@@ -2295,6 +2299,8 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: rgba(205, 247, 239, 0.8); }
   .bg--teal-600-o-40p-ns {
     background-color: rgba(0, 169, 156, 0.4); }
+  .bg--teal-700-o-20p-ns {
+    background-color: rgba(11, 150, 143, 0.2); }
   .bg--teal-700-o-30p-ns {
     background-color: rgba(11, 150, 143, 0.3); }
   .bg--teal-1000-o-40p-ns {
@@ -3087,6 +3093,8 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: rgba(205, 247, 239, 0.8); }
   .bg--teal-600-o-40p-m {
     background-color: rgba(0, 169, 156, 0.4); }
+  .bg--teal-700-o-20p-m {
+    background-color: rgba(11, 150, 143, 0.2); }
   .bg--teal-700-o-30p-m {
     background-color: rgba(11, 150, 143, 0.3); }
   .bg--teal-1000-o-40p-m {
@@ -3879,6 +3887,8 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     background-color: rgba(205, 247, 239, 0.8); }
   .bg--teal-600-o-40p-l {
     background-color: rgba(0, 169, 156, 0.4); }
+  .bg--teal-700-o-20p-l {
+    background-color: rgba(11, 150, 143, 0.2); }
   .bg--teal-700-o-30p-l {
     background-color: rgba(11, 150, 143, 0.3); }
   .bg--teal-1000-o-40p-l {
@@ -7383,6 +7393,7 @@ Modifiers:
     --color-name: name of a color variable
     --teal-100-o-80p: Teal 100 (80% opacity)
     --teal-600-o-40p: Teal 600 (40% opacity)
+    --teal-700-o-20p: Teal 700 (20% opacity)
     --teal-700-o-30p: Teal 700 (30% opacity)
     --teal-1000-o-40p: Teal 1000 (40% opacity)
     --blue-700-o-20p: Blue 700 (20% opacity)
@@ -9330,6 +9341,8 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     background-color: rgba(205, 247, 239, 0.8); }
   .c--teal-600-o-40p-ns {
     background-color: rgba(0, 169, 156, 0.4); }
+  .c--teal-700-o-20p-ns {
+    background-color: rgba(11, 150, 143, 0.2); }
   .c--teal-700-o-30p-ns {
     background-color: rgba(11, 150, 143, 0.3); }
   .c--teal-1000-o-40p-ns {
@@ -10121,6 +10134,8 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     background-color: rgba(205, 247, 239, 0.8); }
   .c--teal-600-o-40p-m {
     background-color: rgba(0, 169, 156, 0.4); }
+  .c--teal-700-o-20p-m {
+    background-color: rgba(11, 150, 143, 0.2); }
   .c--teal-700-o-30p-m {
     background-color: rgba(11, 150, 143, 0.3); }
   .c--teal-1000-o-40p-m {
@@ -10912,6 +10927,8 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
     background-color: rgba(205, 247, 239, 0.8); }
   .c--teal-600-o-40p-l {
     background-color: rgba(0, 169, 156, 0.4); }
+  .c--teal-700-o-20p-l {
+    background-color: rgba(11, 150, 143, 0.2); }
   .c--teal-700-o-30p-l {
     background-color: rgba(11, 150, 143, 0.3); }
   .c--teal-1000-o-40p-l {

--- a/packets/seedlings/src/_background.scss
+++ b/packets/seedlings/src/_background.scss
@@ -12,6 +12,7 @@ Modifiers:
     --light-translucent: light transparent
     --teal-100-o-80p: Teal 100 (80% opacity)
     --teal-600-o-40p: Teal 600 (40% opacity)
+    --teal-700-o-20p: Teal 700 (20% opacity)
     --teal-700-o-30p: Teal 700 (30% opacity)
     --teal-1000-o-40p: Teal 1000 (40% opacity)
     --blue-700-o-20p: Blue 700 (20% opacity)
@@ -56,6 +57,9 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
       }
       .bg--teal-600-o-40p#{$breakpoint-name} {
         background-color: rgba(get-color(teal, 600), .4);
+      }
+      .bg--teal-700-o-20p#{$breakpoint-name} {
+        background-color: rgba(get-color(teal, 700), .2);
       }
       .bg--teal-700-o-30p#{$breakpoint-name} {
         background-color: rgba(get-color(teal, 700), .3);
@@ -103,6 +107,9 @@ Example: <div class="db pa300 {{modifier}}">{{label}}</div>
     }
     .bg--teal-600-o-40p {
       background-color: rgba(get-color(teal, 600), .4);
+    }
+    .bg--teal-700-o-20p {
+      background-color: rgba(get-color(teal, 700), .2);
     }
     .bg--teal-700-o-30p {
       background-color: rgba(get-color(teal, 700), .3);

--- a/packets/seedlings/src/_background.scss
+++ b/packets/seedlings/src/_background.scss
@@ -12,8 +12,8 @@ Modifiers:
     --light-translucent: light transparent
     --teal-100-o-80p: Teal 100 (80% opacity)
     --teal-600-o-40p: Teal 600 (40% opacity)
-    --teal-700-o-20p: Teal 700 (20% opacity)
     --teal-700-o-30p: Teal 700 (30% opacity)
+    --teal-700-o-20p: Teal 700 (20% opacity)
     --teal-1000-o-40p: Teal 1000 (40% opacity)
     --blue-700-o-20p: Blue 700 (20% opacity)
     --neutral-0-o-10p: Neutral 0 (10% opacity)

--- a/packets/seedlings/src/_color.scss
+++ b/packets/seedlings/src/_color.scss
@@ -10,6 +10,7 @@ Modifiers:
     --color-name: name of a color variable
     --teal-100-o-80p: Teal 100 (80% opacity)
     --teal-600-o-40p: Teal 600 (40% opacity)
+    --teal-700-o-20p: Teal 700 (20% opacity)
     --teal-700-o-30p: Teal 700 (30% opacity)
     --teal-1000-o-40p: Teal 1000 (40% opacity)
     --blue-700-o-20p: Blue 700 (20% opacity)
@@ -49,6 +50,9 @@ Example: <div class="f500 {{modifier}}"><p>The quick brown fox jumped over the l
       }
       .c--teal-600-o-40p#{$breakpoint-name} {
         background-color: rgba(get-color(teal, 600), .4);
+      }
+      .c--teal-700-o-20p#{$breakpoint-name} {
+        background-color: rgba(get-color(teal, 700), .2);
       }
       .c--teal-700-o-30p#{$breakpoint-name} {
         background-color: rgba(get-color(teal, 700), .3);


### PR DESCRIPTION
## Description:

This PR is a dependency for the Free Tools landing page to add a teal-700 with an opacity of 20%

-[Related PR](https://github.com/sproutsocial/web-insights-application/pull/3030)

## GitHub pages build link:

N/A

## Jira:

- [Related Story](https://sprout.atlassian.net/browse/MBC-8148)

## Screenshots:

<!--- Drag relevant screenshots into the GitHub edit window below -->
<img width="1754" alt="Screen Shot 2022-07-13 at 10 50 19 AM" src="https://user-images.githubusercontent.com/91143390/178776719-f4ae07bf-4e9b-4542-b39d-306668daf1ce.png">

