### PR TITLE
ignore dist for all packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .DS_Store
+dist
 
 # Project dependencies
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git


### PR DESCRIPTION
Now that we've sanitized repo we should ignore our each package `dist` from being committed to the repo