### PR TITLE
remove nohoist option in yarn workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
   "workspaces": {
     "packages": [
       "packages/*"
-    ],
-    "nohoist": [
-      "**/@sproutsocial/seeds-*"
     ]
   },
   "scripts": {


### PR DESCRIPTION
Yarn Workspaces handles symlinking of packages better than the older version of Lerna and we no longer need to disable hoisting for the seeds-utils package. 

