### PR TITLE
FIX: Revert JS tokens to be literals instead of strings for all packages.

### DIFF
--- a/.changeset/tasty-beds-drum.md
+++ b/.changeset/tasty-beds-drum.md
@@ -1,0 +1,12 @@
+---
+"@sproutsocial/seeds-border": minor
+"@sproutsocial/seeds-color": minor
+"@sproutsocial/seeds-depth": minor
+"@sproutsocial/seeds-motion": minor
+"@sproutsocial/seeds-networkcolor": minor
+"@sproutsocial/seeds-space": minor
+"@sproutsocial/seeds-typography": minor
+"@sproutsocial/seeds-utils": minor
+---
+
+revert js object keys to literals instead of strings

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ yarn-debug.log*
 yarn-error.log*
 .DS_Store
 dist
+build
 
 # Project dependencies
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
@@ -15,3 +16,4 @@ yarn-error.log
 .idea
 .npmrc
 .turbo
+.env

--- a/packages/seeds-border/config.json
+++ b/packages/seeds-border/config.json
@@ -27,7 +27,7 @@
       "files": [
         {
           "destination": "seeds-border.js",
-          "format": "javascript/module-flat",
+          "format": "template/js-exports",
           "options": { "showFileHeader": false }
         },
         {

--- a/packages/seeds-color/config.json
+++ b/packages/seeds-color/config.json
@@ -27,7 +27,7 @@
       "files": [
         {
           "destination": "seeds-color.js",
-          "format": "javascript/module-flat",
+          "format": "template/js-exports",
           "options": { "showFileHeader": false }
         },
          {

--- a/packages/seeds-depth/config.json
+++ b/packages/seeds-depth/config.json
@@ -27,7 +27,7 @@
       "files": [
         {
           "destination": "seeds-depth.js",
-          "format": "javascript/module-flat",
+          "format": "template/js-exports",
           "options": { "showFileHeader": false }
         },
         {

--- a/packages/seeds-motion/config.json
+++ b/packages/seeds-motion/config.json
@@ -27,7 +27,7 @@
       "files": [
         {
           "destination": "seeds-motion.js",
-          "format": "javascript/module-flat",
+          "format": "template/js-exports",
           "options": { "showFileHeader": false }
         },
         {

--- a/packages/seeds-networkcolor/config.json
+++ b/packages/seeds-networkcolor/config.json
@@ -28,7 +28,7 @@
       "files": [
         {
           "destination": "seeds-networkcolor.js",
-          "format": "javascript/module-flat",
+          "format": "template/js-exports",
           "options": { "showFileHeader": false }
         },
         {

--- a/packages/seeds-space/config.json
+++ b/packages/seeds-space/config.json
@@ -28,7 +28,7 @@
       "files": [
         {
           "destination": "seeds-space.js",
-          "format": "javascript/module-flat",
+          "format": "template/js-exports",
           "options": { "showFileHeader": false }
         },
         {

--- a/packages/seeds-typography/config.json
+++ b/packages/seeds-typography/config.json
@@ -28,7 +28,7 @@
       "files": [
         {
           "destination": "seeds-typography.js",
-          "format": "javascript/module-flat",
+          "format": "template/js-exports-typography",
           "options": { "showFileHeader": false }
         },
         {


### PR DESCRIPTION
<!--- Please add Jira story (if applicable) at start of your PR title (ex: "SEEDS-123 ...") -->

## Description:
The `seeds-typographyv3.3.0` accidentally changed the JS export to strings ie. `const token = { "font1": value }` instead of a literal value `const token = { font1: value }`. 

This was an unintentional breaking change for the `seeds-typography`. We are reverting all packages in case the issue is spread to other packages as well. 

## Screenshots:
original
![Screen Shot 2023-02-28 at 2 44 10 PM](https://user-images.githubusercontent.com/29648040/221975243-f30541b2-f781-4c7a-a99b-0b895aef5471.png)

breaking change
![image (3)](https://user-images.githubusercontent.com/29648040/221975395-36d7dcd1-9dd9-4745-86c7-d51f42c6cef3.png)