### PR TITLE
[DS-2085]- Fix seeds-typography .d.ts file

### DIFF
--- a/.changeset/stale-planets-wash.md
+++ b/.changeset/stale-planets-wash.md
@@ -1,0 +1,5 @@
+---
+"@sproutsocial/seeds-typography": patch
+---
+
+git status

--- a/packages/seeds-typography/config.json
+++ b/packages/seeds-typography/config.json
@@ -33,7 +33,7 @@
         },
         {
           "destination": "seeds-typography.d.ts",
-          "format": "typescript/es6-declarations",
+          "format": "template/ts-exports-typography",
           "options": { "showFileHeader": false }
         }
       ]

--- a/packages/seeds-utils/style-dictionary/templates/ts-exports-typography.hbs
+++ b/packages/seeds-utils/style-dictionary/templates/ts-exports-typography.hbs
@@ -14,5 +14,19 @@ export const {{ other.name }}: string;
 {{/ifEquals}}
 {{/each}}
 {{/each}}
-declare const defaultExport: {[index:string]: string | {fontSize: string, lineHeight: string}};
+
+{{!-- OPTION 1 for default export --}}
+{{!-- declare const defaultExport: {[index:string]: string | {fontSize: string, lineHeight: string}};
+export default defaultExport; --}}
+
+
+{{!-- OPTION 2 for default export --}}
+type TypographySizeType = {
+  fontSize: string;
+  lineHeight: string;
+};
+
+type TypographyExport = Record<string, string | TypographySizeType>;
+
+declare const defaultExport: TypographyExport;
 export default defaultExport;


### PR DESCRIPTION
The' seeds-typography' currently uses the wrong template file to generate `.d.ts` files for types. To fix this I'm updating the `seeds-typography` config to utilize the custom `ts-exports-typography`. 

I'm also updating the default export type to read slightly better.